### PR TITLE
Address failures to open the application, displaying the Designer perspe...

### DIFF
--- a/plugins/org.teiid.designer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.teiid.designer.ui/META-INF/MANIFEST.MF
@@ -75,6 +75,8 @@ Require-Bundle: org.eclipse.ui.cheatsheets;bundle-version="[3.4.200,4.0.0)",
  org.teiid.designer.legacy;bundle-version="[8.0.0,9.0.0)",
  teiid_embedded_query;bundle-version="[8.0.0,9.0.0)",
  org.teiid.designer.extension;bundle-version="[8.0.0,9.0.0)",
- org.teiid.designer.udf;bundle-version="[8.0.0,9.0.0)"
+ org.teiid.designer.udf;bundle-version="[8.0.0,9.0.0)",
+ org.eclipse.ui.navigator;bundle-version="3.5.200",
+ org.eclipse.ui.navigator.resources;bundle-version="3.4.400"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/ModelerPerspectiveFactory.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/ModelerPerspectiveFactory.java
@@ -20,8 +20,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.IFolderLayout;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveFactory;
-import org.teiid.designer.ui.UiConstants.Extensions;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.teiid.designer.ui.UiConstants.ExtensionPoints.ModelerPerspectiveContributorExtension;
+import org.teiid.designer.ui.UiConstants.Extensions;
 import org.teiid.designer.ui.util.IModelerPerspectiveContributor;
 import org.teiid.designer.ui.util.PerspectiveObject;
 
@@ -73,7 +74,7 @@ implements Extensions, IPerspectiveFactory, ModelerPerspectiveContributorExtensi
     @Override
 	public void createInitialLayout(IPageLayout theLayout) {
         theLayout.addPerspectiveShortcut(PERSPECTIVE);
-
+        
         String editorArea = theLayout.getEditorArea();
 
         //
@@ -85,6 +86,8 @@ implements Extensions, IPerspectiveFactory, ModelerPerspectiveContributorExtensi
                                                          editorArea);
         addView(Explorer.VIEW, topLeftFolder, theLayout);
         addView(OUTLINE_VIEW, topLeftFolder, theLayout);
+        addView(ProjectExplorer.VIEW_ID, topLeftFolder, theLayout);
+        
         topLeftFolder.addPlaceholder(DATATYPE_HIERARCHY_VIEW);
         topLeftFolder.addPlaceholder(METAMODELS_VIEW);
 

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/actions/PasteInResourceAction.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/actions/PasteInResourceAction.java
@@ -20,7 +20,10 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.dnd.FileTransfer;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.CopyProjectOperation;
 import org.eclipse.ui.actions.SelectionListenerAction;
 import org.eclipse.ui.part.ResourceTransfer;
@@ -382,8 +385,29 @@ public class PasteInResourceAction extends ModelObjectAction implements UiConsta
          */
         @Override
         protected boolean updateSelection( IStructuredSelection selection ) {
-            if (!super.updateSelection(selection)) return false;
-
+            
+            /* 
+             * Only update selection if we have a visible workbench window as only then will
+             * the system clipboard be ready.
+             */
+            IWorkbench workbench = PlatformUI.getWorkbench();
+            if (workbench == null)
+                return false;
+            
+            IWorkbenchWindow workbenchWindow = workbench.getActiveWorkbenchWindow();
+            if (workbenchWindow == null)
+                return false;
+            
+            if (workbenchWindow.getShell() == null || ! workbenchWindow.getShell().isVisible())
+                return false;
+            
+            /*
+             * If selection is empty then bale out since the paste has nothing to
+             * aim at anyway
+             */
+            if (selection == null || selection.isEmpty())
+                return false;
+            
             try {
                 // clipboard must have resources or files
                 ResourceTransfer resTransfer = ResourceTransfer.getInstance();

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IMarkerDelta;
 import org.eclipse.core.resources.IProject;
@@ -66,6 +65,7 @@ import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.ISelectionListener;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -1158,7 +1158,26 @@ public class ModelExplorerResourceNavigator extends ResourceNavigator
      */
     @Override
     protected void updateActionBars( IStructuredSelection selection ) {
+        /* 
+         * Workaround that addresses a problem with the parent navigator's paste action
+         * which calls the system clipboard.
+         * 
+         * Only update selection if we have a visible workbench window as only then will
+         * the system clipboard be ready.
+         */
+        IWorkbench workbench = PlatformUI.getWorkbench();
+        if (workbench == null)
+            return;
+        
+        IWorkbenchWindow workbenchWindow = workbench.getActiveWorkbenchWindow();
+        if (workbenchWindow == null)
+            return;
+        
+        if (workbenchWindow.getShell() == null || ! workbenchWindow.getShell().isVisible())
+            return;
+        
         super.updateActionBars(selection);
+        
         if (renameAction != null) {
             renameAction.selectionChanged(selection);
         }


### PR DESCRIPTION
...ctive
- The TabbedPropertySheetTitleProvider class requires the Project Explorer
  view to be available in the workbench. The workaround at the moment is to
  display this view at the rear of the ModelExplorer stack. Not ideal but
  solves the problem at the moment.
- Appears that the application's clipboard is not initialised until the
  workbench window is fully visible.
- The navigator view has a paste action attached as well as the Model
  Explorer view has its own paste action attached. Both actions have their
  selections updated prior to the workbench window appearing but since the
  clipboard is not initialised (due to a CompatibilityView not being inited),
  exceptions are generated.
- Workaround is to stop the update of the paste action until the workbench
  has been displayed. Since the paste action necessarily involves selecting
  something to copy then a selection update will occur and so always
  correctly enable the paste action appropriately.
