### PR TITLE
TEIIDDES-1514 Models Having Only Built-In MED Properties Should Not Be Decorated With the Extended Model Overlay Image

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/extension/EmfModelObjectExtensionAssistant.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/extension/EmfModelObjectExtensionAssistant.java
@@ -196,7 +196,7 @@ public class EmfModelObjectExtensionAssistant extends ModelObjectExtensionAssist
      */
     @Override
     public Collection<ModelExtensionPropertyDefinition> getPropertyDefinitions(Object modelObject) throws Exception {
-        if (!(modelObject instanceof EObject)) {
+        if (!(modelObject instanceof EObject) || !supportsMyNamespace(modelObject)) {
             return Collections.emptyList();
         }
 

--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/extension/deprecated/DeprecatedModelExtensionAssistant.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/extension/deprecated/DeprecatedModelExtensionAssistant.java
@@ -135,24 +135,6 @@ public class DeprecatedModelExtensionAssistant extends EmfModelObjectExtensionAs
         getRestAssistant().setPropertyValue(modelObject, NEW_URI, uriValue);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.teiid.designer.core.extension.EmfModelObjectExtensionAssistant#getPropertyDefinition(java.lang.Object, java.lang.String)
-     */
-    @Override
-    protected ModelExtensionPropertyDefinition getPropertyDefinition(Object modelObject,
-                                                                     String propId) throws Exception {
-        ModelExtensionPropertyDefinition propDefn = super.getPropertyDefinition(modelObject, propId);
-
-        if (propDefn == null) {
-            return null;
-        }
-
-        String value = getOverriddenValue(modelObject, propDefn.getId());
-        return (CoreStringUtil.isEmpty(value) ? null : propDefn);
-    }
-
     private ModelObjectExtensionAssistant getRestAssistant() {
         if (this.restAssistant == null) {
             this.restAssistant = (ModelObjectExtensionAssistant)ExtensionPlugin.getInstance()

--- a/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/ExtensionConstants.java
+++ b/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/ExtensionConstants.java
@@ -21,14 +21,29 @@ import org.teiid.core.designer.util.LoggingUtil;
  */
 public interface ExtensionConstants {
 
+    /**
+     * The plugin identifier. Value is {@value}.
+     */
     String PLUGIN_ID = ExtensionConstants.class.getPackage().getName();
 
+    /**
+     * The bundles logging and i18n utilities.
+     */
     PluginUtil UTIL = new LoggingUtil(PLUGIN_ID);
 
+    /**
+     * The model extension definition schema file name. Value is {@value}.
+     */
     String SCHEMA_FILENAME = "modelExtension.xsd"; //$NON-NLS-1$
 
+    /**
+     * The model extension definition file extension. Value is {@value}.
+     */
     String MED_EXTENSION = "mxd"; //$NON-NLS-1$
 
+    /**
+     * The model extension definition file extension prefixed with a dot.
+     */
     String DOT_MED_EXTENSION = '.' + MED_EXTENSION;
 
     /**
@@ -55,6 +70,9 @@ public interface ExtensionConstants {
         String VERSION = "version"; //$NON-NLS-1$
     }
 
+    /**
+     * Namespace-related names found in the model extension definition schema.
+     */
     interface Namespaces {
         String NS_XSI = "xsi"; //$NON-NLS-1$
         String NS_MED = "p"; //$NON-NLS-1$
@@ -78,6 +96,9 @@ public interface ExtensionConstants {
         String PROPERTY = "property"; //$NON-NLS-1$
     }
 
+    /**
+     * Compares {@link Locale}s based on display language.
+     */
     Comparator LOCALE_COMPARATOR = new Comparator<Locale>() {
 
         /**
@@ -109,6 +130,11 @@ public interface ExtensionConstants {
 
         String CHANGE_HEADER_INFO = "CHANGE_HEADER_INFO"; //$NON-NLS-1$
         
+        /**
+         * An operation that would indicate a MED has been saved to a model.
+         */
+        String SHOW_CONTAINED_IN_MODEL = "SHOW_CONTAINED_IN_MODEL"; //$NON-NLS-1$
+
         String SHOW_IN_REGISTRY = "SHOW_IN_REGISTRY"; //$NON-NLS-1$
     }
 

--- a/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/definition/ModelExtensionAssistant.java
+++ b/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/definition/ModelExtensionAssistant.java
@@ -65,11 +65,13 @@ public class ModelExtensionAssistant implements ExtensionConstants {
                                                                     Set<String> modelTypes,
                                                                     String description,
                                                                     String version ) {
-        this.definition = new ModelExtensionDefinition(this, namespacePrefix, namespaceUri, metamodelUri, description, version);
+        if ((this.definition == null) || !this.definition.isBuiltIn()) {
+            this.definition = new ModelExtensionDefinition(this, namespacePrefix, namespaceUri, metamodelUri, description, version);
 
-        if ((modelTypes != null) && !modelTypes.isEmpty()) {
-            for (String modelType : modelTypes) {
-                addSupportedModelType(modelType);
+            if ((modelTypes != null) && !modelTypes.isEmpty()) {
+                for (String modelType : modelTypes) {
+                    addSupportedModelType(modelType);
+                }
             }
         }
 
@@ -82,15 +84,14 @@ public class ModelExtensionAssistant implements ExtensionConstants {
      * @param medHeader the ModelExtensionDefinitionHeader (cannot be <code>null</code>)
      * @return the new model extension definition (never <code>null</code>)
      */
-    public ModelExtensionDefinition createModelExtensionDefinition( ModelExtensionDefinitionHeader medHeader ) {
+    public ModelExtensionDefinition createModelExtensionDefinition(ModelExtensionDefinitionHeader medHeader) {
         CoreArgCheck.isNotNull(medHeader, "ModelExtensionDefinitionHeader is null"); //$NON-NLS-1$
-        ModelExtensionDefinition med = createModelExtensionDefinition(medHeader.getNamespacePrefix(), medHeader.getNamespaceUri(),
-                                                                      medHeader.getMetamodelUri(),
-                                                                      medHeader.getSupportedModelTypes(),
-                                                                      medHeader.getDescription(),
-                                                                      String.valueOf(medHeader.getVersion()));
-
-        return med;
+        return createModelExtensionDefinition(medHeader.getNamespacePrefix(),
+                                              medHeader.getNamespaceUri(),
+                                              medHeader.getMetamodelUri(),
+                                              medHeader.getSupportedModelTypes(),
+                                              medHeader.getDescription(),
+                                              String.valueOf(medHeader.getVersion()));
     }
 
     /**

--- a/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/registry/ModelExtensionRegistry.java
+++ b/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/registry/ModelExtensionRegistry.java
@@ -190,7 +190,7 @@ public final class ModelExtensionRegistry {
      * @return a collection of all the model extension definitions (never <code>null</code>)
      */
     public Collection<ModelExtensionDefinition> getAllDefinitions() {
-        return this.definitions.values();
+        return Collections.unmodifiableCollection(this.definitions.values());
     }
 
     /**
@@ -222,7 +222,8 @@ public final class ModelExtensionRegistry {
     /**
      * Restore the persisted user-defined MEDs from the file system (at the specified path location) into the registry.
      * 
-     * @param userDefinitionsPath
+     * @param userDefinitionsPath the directory path where the MEDs are persisted (can be <code>null</code> ore empty if MEDs are 
+     * not being restored)
      * @return IStatus indicating successful loading.
      */
     public IStatus restoreUserDefinitions( String userDefinitionsPath ) {
@@ -251,8 +252,8 @@ public final class ModelExtensionRegistry {
      * Save all user-defined MEDs that are currently in the registry to the file system (at the specified path location). Any user
      * meds that have been previously saved at the specified location will be overwritten.
      * 
-     * @param userDefinitionsPath
-     * @return IStatus indicating successful loading.
+     * @param userDefinitionsPath the directory path where the MEDs are persisted (can be <code>null</code> ore empty if MEDs are 
+     * not being saved)
      */
     public void saveUserDefinitions( String userDefinitionsPath ) {
         UserExtensionDefinitionsManager mgr = new UserExtensionDefinitionsManager(userDefinitionsPath);
@@ -383,7 +384,7 @@ public final class ModelExtensionRegistry {
     }
 
     /**
-     * @param metamodelURI the metamodel URI being checked (cannot be <code>null</code> or empty)
+     * @param metamodelUri the metamodel URI being checked (cannot be <code>null</code> or empty)
      * @return <code>true</code> if the provided URI is included in the list of extendable metamodel URIs
      */
     public boolean isExtendable( String metamodelUri ) {

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerLabelProvider.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerLabelProvider.java
@@ -134,7 +134,7 @@ public class ModelExplorerLabelProvider extends LabelProvider
     /**
      * Set this label provider's event source
      * 
-     * @param theSource
+     * @param theSource the source of the event (can be <code>null</code>)
      */
     public void setLabelProviderChangedEventSource( IBaseLabelProvider theSource ) {
         this.eventSource = theSource;
@@ -368,7 +368,7 @@ public class ModelExplorerLabelProvider extends LabelProvider
         
         // Lastly, decorate with Extension if applicable
         
-        if( element instanceof IFile ) {
+        if( element instanceof IFile && ModelUtilities.isModelFile((IFile)element)) {
             File file = ((IFile)element).getLocation().toFile();
             ModelExtensionRegistry registry = ExtensionPlugin.getInstance().getRegistry();
 
@@ -376,8 +376,9 @@ public class ModelExplorerLabelProvider extends LabelProvider
                 for (String namespacePrefix : registry.getAllNamespacePrefixes()) {
                     ModelExtensionAssistant assistant = registry.getModelExtensionAssistant(namespacePrefix);
 
-                    if ((assistant instanceof ModelObjectExtensionAssistant)
-                            && ((ModelObjectExtensionAssistant)assistant).hasExtensionProperties(file)) {
+                    if (!assistant.getModelExtensionDefinition().isBuiltIn()
+                        && (assistant instanceof ModelObjectExtensionAssistant)
+                        && ((ModelObjectExtensionAssistant)assistant).supportsMyNamespace(element)) {
                         decoration.addOverlay(UiPlugin.getDefault().getExtensionDecoratorImage(), IDecoration.TOP_LEFT);
                         break;
                     }

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/viewsupport/ModelObjectLabelProvider.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/viewsupport/ModelObjectLabelProvider.java
@@ -68,6 +68,9 @@ public class ModelObjectLabelProvider extends LabelProvider
 
     private ILabelProvider delegate = null;
 
+    /**
+     * Construct a label provider for model objects.
+     */
     public ModelObjectLabelProvider() {
         super();
         delegate = ModelUtilities.getAdapterFactoryLabelProvider();
@@ -137,9 +140,9 @@ public class ModelObjectLabelProvider extends LabelProvider
      * Overloaded getImage necessary for finding icons for EObjects that are not inside a Model. Specifically, this method was
      * written for the New Child/Sibling menu items.
      * 
-     * @param theElement
-     * @param modelType
-     * @return
+     * @param theElement the model object (cannot be <code>null</code>)
+     * @param isVirtual indicates if the model object is from a virtual model
+     * @return the requested image or <code>null</code>
      * @since 4.2
      */
     public Image getImage( final EObject theElement,
@@ -241,8 +244,9 @@ public class ModelObjectLabelProvider extends LabelProvider
 
             try {
                 for (ModelExtensionAssistant assistant : registry.getModelExtensionAssistants(element.getClass().getName())) {
-                    if ((assistant instanceof ModelObjectExtensionAssistant)
-                            && ((ModelObjectExtensionAssistant)assistant).hasExtensionProperties(element)) {
+                    if (!assistant.getModelExtensionDefinition().isBuiltIn()
+                        && (assistant instanceof ModelObjectExtensionAssistant)
+                        && !((ModelObjectExtensionAssistant)assistant).getPropertyDefinitions(element).isEmpty()) {
                         decoration.addOverlay(UiPlugin.getDefault().getExtensionDecoratorImage(), IDecoration.TOP_LEFT);
                         break;
                     }
@@ -328,38 +332,5 @@ public class ModelObjectLabelProvider extends LabelProvider
             return ir;
         }
         return null;
-    }
-
-    /**
-     * Method to provide a way to get an image with the URL instead of EObject and to colorize it based on virtual vs physical.
-     * 
-     * @param theElement
-     * @param url
-     * @return
-     * @since 4.2
-     */
-    public Image getImage( EObject eObj,
-                           Object url ) {
-        Image result = null;
-
-        Image temp = ModelObjectUtilities.getImageFromObject(url);
-        if (temp != null) {
-            ModelResource modelResource = ModelUtilities.getModelResourceForModelObject(eObj);
-            boolean virtual = (ModelUtilities.isVirtual(modelResource));
-
-            String prefix = (virtual) ? "virtual." : "physical."; //$NON-NLS-1$ //$NON-NLS-2$
-            // image registry uses the base image hashCode as key
-            String imageId = prefix + temp.hashCode();
-
-            UiPlugin plugin = UiPlugin.getDefault();
-            if (plugin.isImageRegistered(imageId)) {
-                result = plugin.getImage(imageId);
-            } else {
-                result = UiUtil.createImage(temp, TEMP_COLOR, (virtual) ? VIRTUAL_COLOR : PHYSICAL_COLOR);
-                plugin.registerPluginImage(imageId, result);
-            }
-        }
-
-        return result;
     }
 }


### PR DESCRIPTION
TEIIDDES-1516 Adding Copied MED To Registry Fails And Modifies Original MED
Models are now decorated with the extended model overlay image if the model has at least one saved, non-builtIn MED. EObjects are now decorated with the extended model overlay image if their model has a saved, non-builtIn MED that has properties defined for its model object class. Lots of work in the model manage MED dialog/wizard.
