### PR TITLE
More reference caching removel

### DIFF
--- a/plugins/org.teiid.designer.query.ui/src/org/teiid/query/ui/sqleditor/component/DisplayNodeVisitor.java
+++ b/plugins/org.teiid.designer.query.ui/src/org/teiid/query/ui/sqleditor/component/DisplayNodeVisitor.java
@@ -29,7 +29,6 @@ public final class DisplayNodeVisitor implements ISQLStringVisitorCallback {
     private final boolean dontAppend;
     private int indentLevel;
     private int originalLevel;
-    private final ISQLStringVisitor delegate;
 
     DisplayNodeVisitor(DisplayNode node,
                        boolean dontAppend,
@@ -38,9 +37,6 @@ public final class DisplayNodeVisitor implements ISQLStringVisitorCallback {
         this.dontAppend = dontAppend;
         this.indentLevel = indentLevel;
         this.originalLevel = indentLevel;
-
-        IQueryService queryService = ModelerCore.getTeiidQueryService();
-        delegate = queryService.getCallbackSQLStringVisitor(this);
     }
 
     @Override
@@ -51,6 +47,8 @@ public final class DisplayNodeVisitor implements ISQLStringVisitorCallback {
         }
 
         if ((obj instanceof IExpressionSymbol && !(obj instanceof IAggregateSymbol))) {
+            IQueryService queryService = ModelerCore.getTeiidQueryService();
+            ISQLStringVisitor delegate = queryService.getCallbackSQLStringVisitor(this);
             obj.acceptVisitor(delegate);
             return;
         }

--- a/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/aspects/sql/MappingDocumentFormatter.java
+++ b/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/aspects/sql/MappingDocumentFormatter.java
@@ -586,8 +586,6 @@ public class MappingDocumentFormatter {
 
     private boolean newlines;
 
-    private IMappingDocumentFactory mappingDocumentFactory;
-
     /**
      * Construct an instance of MappingDocumentFormatter.
      */
@@ -607,12 +605,8 @@ public class MappingDocumentFormatter {
     }
     
     private IMappingDocumentFactory getFactory() {
-        if (mappingDocumentFactory == null) {
-            IQueryService queryService = ModelerCore.getTeiidQueryService();
-            mappingDocumentFactory = queryService.getMappingDocumentFactory();
-        }
-        
-        return mappingDocumentFactory;
+        IQueryService queryService = ModelerCore.getTeiidQueryService();
+        return queryService.getMappingDocumentFactory();
     }
 
     private void createAttributeNode( final IMappingElement parent,


### PR DESCRIPTION
- Caching references to visitor, query service and factories is dangerous
  since these can hang around in their parent objects after a change of
  server version and cause class cast exceptions
- SqlTransformationMappingRootValidationRule
  - Especially important with this class since it is create as a singleton
    static and used throughout the life of the application
