### PR TITLE
Panel for default server

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
@@ -2133,17 +2133,20 @@ public class ModelerCore extends Plugin implements DeclarativeTransactionManager
      * @param defaultServer
      */
     public static void setDefaultServer(ITeiidServer defaultServer) {
-        if (defaultServer == null)
-            return;
-        
         if (defaultTeiidServer != null && defaultTeiidServer.equals(defaultServer))
             return;
-        
+
         ITeiidServerVersion oldServerVersion = defaultTeiidServer != null ? defaultTeiidServer.getServerVersion() : null;
-        ITeiidServerVersion newServerVersion = defaultServer.getServerVersion();
-        
+        ITeiidServerVersion newServerVersion = defaultServer != null ? defaultServer.getServerVersion() : null;
+
         defaultTeiidServer = defaultServer;
-        
+
+        if (teiidServerVersionListeners != null) {
+            for (ITeiidServerVersionListener listener : teiidServerVersionListeners) {
+                listener.serverChanged(defaultServer);
+            }
+        }
+
         /* 
          * Compare the versions of the server.
          * 
@@ -2152,20 +2155,19 @@ public class ModelerCore extends Plugin implements DeclarativeTransactionManager
          */
         if (oldServerVersion != null && oldServerVersion.equals(newServerVersion))
             return;
-        
+
         // Server version change has occurred so close all editors and notify server version listeners
-        
         for (IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
             for (IWorkbenchPage page : window.getPages()) {
                 page.closeAllEditors(true);
             }
         }
-        
+
         if (teiidServerVersionListeners == null)
             return;
-        
+
         for (ITeiidServerVersionListener listener : teiidServerVersionListeners) {
-            listener.versionChanged(defaultServer.getServerVersion());
+            listener.versionChanged(getTeiidServerVersion());
         }
     }
     

--- a/plugins/org.teiid.designer.diagram.ui/src/org/teiid/designer/diagram/ui/util/DiagramEntityManager.java
+++ b/plugins/org.teiid.designer.diagram.ui/src/org/teiid/designer/diagram/ui/util/DiagramEntityManager.java
@@ -24,6 +24,7 @@ import org.teiid.designer.core.ModelerCore;
 import org.teiid.designer.diagram.ui.DiagramUiConstants;
 import org.teiid.designer.metamodels.diagram.AbstractDiagramEntity;
 import org.teiid.designer.metamodels.diagram.Diagram;
+import org.teiid.designer.runtime.spi.ITeiidServer;
 import org.teiid.designer.runtime.spi.ITeiidServerVersionListener;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 import org.teiid.designer.ui.UiPlugin;
@@ -62,6 +63,11 @@ public class DiagramEntityManager  {
         }
 
         teiidServerVersionListener = new ITeiidServerVersionListener() {
+
+            @Override
+            public void serverChanged(ITeiidServer server) {
+                // Nothing to do
+            }
 
             @Override
             public void versionChanged(ITeiidServerVersion version) {

--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/ITeiidServerVersionListener.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/ITeiidServerVersionListener.java
@@ -15,6 +15,13 @@ import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 public interface ITeiidServerVersionListener {
 
     /**
+     * Server has been changed
+     *
+     * @param server
+     */
+    void serverChanged(ITeiidServer server);
+
+    /**
      * Version of teiid server has been changed
      * 
      * @param version

--- a/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/util/SqlMappingRootCache.java
+++ b/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/util/SqlMappingRootCache.java
@@ -30,6 +30,7 @@ import org.teiid.designer.metamodels.transformation.SqlTransformation;
 import org.teiid.designer.metamodels.transformation.SqlTransformationMappingRoot;
 import org.teiid.designer.query.sql.ISQLConstants;
 import org.teiid.designer.query.sql.lang.ICommand;
+import org.teiid.designer.runtime.spi.ITeiidServer;
 import org.teiid.designer.runtime.spi.ITeiidServerVersionListener;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 import org.teiid.designer.transformation.TransformationPlugin;
@@ -60,6 +61,11 @@ public class SqlMappingRootCache implements ISQLConstants {
     static {
         teiidServerVersionListener = new ITeiidServerVersionListener() {
             
+            @Override
+            public void serverChanged(ITeiidServer server) {
+                // Nothing to do
+            }
+
             @Override
             public void versionChanged(ITeiidServerVersion version) {
                 /*

--- a/plugins/org.teiid.designer.udf/src/org/teiid/designer/udf/UdfManager.java
+++ b/plugins/org.teiid.designer.udf/src/org/teiid/designer/udf/UdfManager.java
@@ -46,6 +46,7 @@ import org.teiid.designer.metamodels.relational.ProcedureParameter;
 import org.teiid.designer.metamodels.relational.RelationalPackage;
 import org.teiid.designer.metamodels.relational.util.PushdownFunctionData;
 import org.teiid.designer.query.IQueryService;
+import org.teiid.designer.runtime.spi.ITeiidServer;
 import org.teiid.designer.runtime.spi.ITeiidServerVersionListener;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 
@@ -81,6 +82,11 @@ public final class UdfManager implements IResourceChangeListener {
 
     private ITeiidServerVersionListener teiidServerVersionListener = new ITeiidServerVersionListener() {
         
+        @Override
+        public void serverChanged(ITeiidServer server) {
+            // Nothing to do
+        }
+
         @Override
         public void versionChanged(ITeiidServerVersion version) {
             systemFunctionLibrary = null;

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/i18n.properties
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/i18n.properties
@@ -954,7 +954,11 @@ ModelExplorerResourceNavigator.msg.noDefaultCopyActionFound=No default copy glob
 ModelExplorerResourceNavigator.refreshAction.tooltip=Refresh Markers
 ModelExplorerResourceNavigator.refreshAction.text=Refresh Markers
 ModelExplorerResourceNavigator.restoreStateError.title=Model Explorer Error
-ModelExplorerResourceNavigator.restoreStateError.text=Error restoring Explorer state:\n\n{0}
+ModelExplorerResourceNavigator.restoreStateError.text=Error restoring Explorer state\:\n\n{0}
+ModelExplorerResourceNavigator.defaultServerTitle=Default Teiid Server
+ModelExplorerResourceNavigator.noDefaultServer=No default server defined
+ModelExplorerResourceNavigator.defaultServerPrefix=Server: 
+ModelExplorerResourceNavigator.defaultServerVersionPrefix=Targeted Version: 
 
 #=================================================================================================================================
 # SortModelContentsAction


### PR DESCRIPTION
PEOPLE MAY WANT TO HAVE A LOOK BEFORE IT IS MERGED!!
- Provides a small collapsible panel that shows the current default teiid
  server and version
- ModelerCore
  - Need to allow server manager to set the default server to null if all
    servers are deleted
  - Notify listeners of server change even if there is not a server version
    change
- ITeiidServerVersionListener
  - Addition of method for serverChanged so listeners can be notified of
    a change of server even without a change of server version
- ModelExporerResourceNavigator
  - Adds form section to bottom of view, showing current default server and
    its version.
  - Hyperlinks to servers view from value of server
  - Updates on server and server version changes
