### PR TITLE
TEIIDDES-1583, TEIIDDES-1585, TEIIDDES-1589

### DIFF
--- a/komodo-common/src/main/java/org/komodo/common/io/NullWriter.java
+++ b/komodo-common/src/main/java/org/komodo/common/io/NullWriter.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.common.io;
+
+import java.io.Writer;
+
+/**
+ * A writer that ignores all characters.
+ */
+public class NullWriter extends Writer {
+
+    /**
+     * The shared null writer.
+     */
+    public static final NullWriter SHARED = new NullWriter();
+
+    /**
+     * Don't allow public construction.
+     */
+    private NullWriter() {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#append(char)
+     */
+    @Override
+    public Writer append(final char c) {
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#append(java.lang.CharSequence)
+     */
+    @Override
+    public Writer append(final CharSequence csq) {
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#append(java.lang.CharSequence, int, int)
+     */
+    @Override
+    public Writer append(final CharSequence csq,
+                         final int start,
+                         final int end) {
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#close()
+     */
+    @Override
+    public void close() {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#flush()
+     */
+    @Override
+    public void flush() {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#write(char[])
+     */
+    @Override
+    public void write(final char[] cbuf) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#write(char[], int, int)
+     */
+    @Override
+    public void write(final char[] chars,
+                      final int offset,
+                      final int length) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#write(int)
+     */
+    @Override
+    public void write(final int c) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#write(java.lang.String)
+     */
+    @Override
+    public void write(final String str) {
+        // nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.io.Writer#write(java.lang.String, int, int)
+     */
+    @Override
+    public void write(final String str,
+                      final int off,
+                      final int len) {
+        // nothing to do
+    }
+
+}

--- a/komodo-repository/src/main/java/org/komodo/repository/SoaRepositories.java
+++ b/komodo-repository/src/main/java/org/komodo/repository/SoaRepositories.java
@@ -22,7 +22,7 @@ public class SoaRepositories {
     private static final Logger LOGGER = LoggerFactory.getLogger(SoaRepositories.class);
 
     private ConcurrentMap<String, RepositoryProvider> providers;
-    private ConcurrentMap<String, SoaRepository> repositories;
+    protected ConcurrentMap<String, SoaRepository> repositories;
 
     /**
      * If a repository is created, a connection to the repository is attempted.

--- a/komodo-repository/src/main/java/org/komodo/repository/artifact/teiid/EntryArtifact.java
+++ b/komodo-repository/src/main/java/org/komodo/repository/artifact/teiid/EntryArtifact.java
@@ -26,7 +26,7 @@ public interface EntryArtifact extends Artifact {
          */
         @Override
         public String getId() {
-            return "TeiidImportVdb"; //$NON-NLS-1$
+            return "TeiidVdbEntry"; //$NON-NLS-1$
         }
 
     };

--- a/komodo-repository/src/main/java/org/komodo/repository/artifact/teiid/ImportVdbArtifact.java
+++ b/komodo-repository/src/main/java/org/komodo/repository/artifact/teiid/ImportVdbArtifact.java
@@ -26,7 +26,7 @@ public interface ImportVdbArtifact extends Artifact {
          */
         @Override
         public String getId() {
-            return "TeiidVdbEntry"; //$NON-NLS-1$
+            return "TeiidImportVdb"; //$NON-NLS-1$
         }
 
     };

--- a/komodo-repository/src/test/java/org/komodo/repository/RepositoryTest.java
+++ b/komodo-repository/src/test/java/org/komodo/repository/RepositoryTest.java
@@ -15,11 +15,13 @@ import org.komodo.common.util.Precondition;
 import org.komodo.repository.artifact.Artifact;
 
 /**
- * The base class for Komodo repository artifact tests. The static SOA repository must be set by the subclass.
+ * The base class for Komodo repository artifact tests. Both the static {@link SoaRepositories} and the static {@link SoaRepository}
+ * <em>must</em> be constructed by subclasses.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public abstract class RepositoryTest {
 
+    protected static SoaRepositories _repositories;
     protected static SoaRepository _repository;
 
     /**

--- a/komodo-repository/src/test/java/org/komodo/repository/RepositoryTestCache.java
+++ b/komodo-repository/src/test/java/org/komodo/repository/RepositoryTestCache.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.repository;
+
+import java.net.UnknownHostException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.komodo.common.util.StringUtil;
+
+/**
+ * An implementation of a {@link SoaRepositories} that can be seeded with {@link SoaRepository repositories}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public class RepositoryTestCache extends SoaRepositories {
+
+    public RepositoryTestCache() {
+        this.repositories = new ConcurrentHashMap<String, SoaRepository>();
+    }
+
+    public RepositoryTestCache(final SoaRepository repository) {
+        this();
+        add(repository);
+    }
+
+    public void add(final SoaRepository repository) {
+        assert (repository != null) : "repository cannot be null when adding to the repository test cache";
+        this.repositories.putIfAbsent(repository.getUrl(), repository);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.SoaRepositories#get(java.lang.String, boolean)
+     */
+    @Override
+    public SoaRepository get(final String url,
+                             final boolean connectWhenCreating) throws Exception {
+        assert !StringUtil.isEmpty(url) : "url is null";
+        final SoaRepository repository = this.repositories.get(url);
+
+        if (repository == null) {
+            throw new UnknownHostException(url);
+        }
+
+        return repository;
+    }
+
+}

--- a/komodo-repository/src/test/java/org/komodo/repository/sramp/SrampCleanableRepository.java
+++ b/komodo-repository/src/test/java/org/komodo/repository/sramp/SrampCleanableRepository.java
@@ -7,7 +7,9 @@
 */
 package org.komodo.repository.sramp;
 
+import org.jboss.resteasy.test.EmbeddedContainer;
 import org.komodo.repository.Cleanable;
+import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.jcr.modeshape.JCRRepositoryCleaner;
 
 /**
@@ -43,6 +45,17 @@ public class SrampCleanableRepository extends SrampRepository implements Cleanab
     @Override
     public void clean() throws Exception {
         this.cleaner.clean();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.sramp.SrampRepository#disconnect()
+     */
+    @Override
+    public void disconnect() throws Exception {
+        EmbeddedContainer.stop();
+        PersistenceFactory.newInstance().shutdown();
     }
 
 }

--- a/komodo-repository/src/test/java/org/komodo/repository/sramp/SrampTest.java
+++ b/komodo-repository/src/test/java/org/komodo/repository/sramp/SrampTest.java
@@ -19,13 +19,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.komodo.common.util.CollectionUtil;
 import org.komodo.repository.RepositoryTest;
+import org.komodo.repository.RepositoryTestCache;
 import org.komodo.repository.SoaRepository;
 import org.komodo.repository.artifact.Artifact;
 import org.overlord.sramp.atom.providers.HttpResponseProvider;
 import org.overlord.sramp.atom.providers.OntologyProvider;
 import org.overlord.sramp.atom.providers.SrampAtomExceptionProvider;
 import org.overlord.sramp.common.SrampModelUtils;
-import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.jcr.JCRRepository;
 import org.overlord.sramp.server.atom.services.ArtifactResource;
 import org.overlord.sramp.server.atom.services.BatchResource;
@@ -47,8 +47,7 @@ public abstract class SrampTest extends RepositoryTest implements SrampRepositor
     @AfterClass
     public static void shutdownRepository() throws Exception {
         if (_repository != null) {
-            EmbeddedContainer.stop();
-            PersistenceFactory.newInstance().shutdown();
+            _repository.disconnect();
         }
     }
 
@@ -77,6 +76,7 @@ public abstract class SrampTest extends RepositoryTest implements SrampRepositor
         providerFactory.registerProvider(OntologyProvider.class);
 
         _repository = new SrampCleanableRepository();
+        _repositories = new RepositoryTestCache(_repository);
     }
 
     /**

--- a/komodo-shell/src/main/java/org/komodo/shell/ShellConstants.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/ShellConstants.java
@@ -13,8 +13,18 @@ public interface ShellConstants {
     String NAMESPACE = "komodo"; //$NON-NLS-1$ 
 
     /**
-     * The shell context variable name for the command's repository.
+     * The shell context variable name used for obtaining the SOA repository the shell is connected to.
      */
-    QName KOMODO_REPOSITORY_QNAME = new QName(NAMESPACE, "soa-repository"); //$NON-NLS-1$
+    QName CONNECTED_SOA_REPOSITORY = new QName(NAMESPACE, "connected-soa-repository"); //$NON-NLS-1$
+
+    /**
+     * The shell context variable name used for obtaining the default SOA repository URL.
+     */
+    QName DEFAULT_REPOSITORY_URL = new QName(NAMESPACE, "default-soa-repository-url"); //$NON-NLS-1$
+
+    /**
+     * The shell context variable name used for obtaining the command's SOA repository cache.
+     */
+    QName SOA_REPOSITORIES = new QName(NAMESPACE, "soa-repositories"); //$NON-NLS-1$
 
 }

--- a/komodo-shell/src/main/java/org/komodo/shell/ShellI18n.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/ShellI18n.java
@@ -17,15 +17,19 @@ public class ShellI18n extends I18n {
 
     public static String addVdbCommandHelp;
     public static String addVdbCommandUsage;
+    public static String commandCanceled;
     public static String commandError;
-    public static String connectionNotFound;
     public static String connectKomodoCommandHelp;
     public static String connectKomodoCommandUsage;
+    public static String errorAddingVdb;
     public static String failedToOpenStream;
     public static String getVdbCommandHelp;
     public static String getVdbCommandUsage;
+    public static String invalidNumberCommandArgs;
     public static String matchingVdbsFoundInRepository;
     public static String noMatchingVdbsFoundInRepository;
+    public static String repositoryCacheNotFound;
+    public static String repositoryNotFound;
     public static String successfulConnection;
     public static String vdbAddedToRepository;
     public static String vdbArtifactMissingAfterAdd;

--- a/komodo-shell/src/main/java/org/komodo/shell/command/AddVdbCommand.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/AddVdbCommand.java
@@ -9,7 +9,7 @@ package org.komodo.shell.command;
 
 import java.io.InputStream;
 import org.komodo.common.i18n.I18n;
-import org.komodo.common.util.Precondition;
+import org.komodo.common.util.CollectionUtil;
 import org.komodo.common.util.StringUtil;
 import org.komodo.repository.SoaRepository;
 import org.komodo.repository.artifact.Artifact;
@@ -19,7 +19,7 @@ import org.komodo.shell.ShellI18n;
 /**
  * A shell command that adds a VDB to the repository.  
  */
-public class AddVdbCommand extends KomodoCommand {
+public class AddVdbCommand extends KomodoCommand<Artifact> {
 
     /**
      * The unqualified name of the add VDB command. Value is {@value}.
@@ -46,39 +46,36 @@ public class AddVdbCommand extends KomodoCommand {
      * @see org.komodo.shell.command.KomodoCommand#doExecute(java.lang.String[])
      */
     @Override
-    protected Object doExecute(final String... args) throws Exception {
-        Precondition.notNull(args, "args"); //$NON-NLS-1$
-        Precondition.sizeIs(args, 1, "args"); //$NON-NLS-1$
-        Precondition.notEmpty(args[0], "fileName"); //$NON-NLS-1$
+    protected Artifact doExecute(final String... args) throws Exception {
+        // check for incorrect number of args
+        if (CollectionUtil.isEmpty(args) || (args.length > 1)) {
+            throw new InvalidNumberArgsException(this, (CollectionUtil.isEmpty(args) ? 0 : args.length));
+        }
 
         this.logger.debug("executing '{}' with cancelable '{}' and params '{}'", new Object[] {getClass().getSimpleName(), //$NON-NLS-1$
             isCancelable(), StringUtil.createDelimitedString(args)});
 
-        final String fileName = args[0];
-        final InputStream vdbStream = getResourceAsStream(fileName);
-
-        if (vdbStream == null) {
-            this.logger.error(I18n.bind(ShellI18n.failedToOpenStream, fileName));
-            return ERROR;
-        }
-
         final SoaRepository repository = getRepository();
+        final String vdbFileName = args[0];
 
-        if (repository == null) {
-            print(ShellI18n.connectionNotFound);
-            return ERROR;
+        try {
+            final InputStream vdbStream = getResourceAsStream(vdbFileName);
+
+            if (vdbStream == null) {
+                throw new CommandException(this, I18n.bind(ShellI18n.failedToOpenStream, vdbFileName));
+            }
+
+            final Artifact vdbArtifact = repository.add(vdbStream, VdbArtifact.TYPE);
+
+            if (vdbArtifact == null) {
+                throw new CommandException(this, I18n.bind(ShellI18n.vdbArtifactMissingAfterAdd, vdbFileName));
+            }
+
+            print(I18n.bind(ShellI18n.vdbAddedToRepository, vdbArtifact.getArtifactName()));
+            return vdbArtifact;
+        } catch (final Exception e) {
+            throw new CommandException(this, I18n.bind(ShellI18n.errorAddingVdb, vdbFileName), e);
         }
-
-        final Artifact vdbArtifact = repository.add(vdbStream, VdbArtifact.TYPE);
-
-        if (vdbArtifact == null) {
-            print(I18n.bind(ShellI18n.vdbArtifactMissingAfterAdd, fileName));
-            return ERROR;
-        }
-
-        print(I18n.bind(ShellI18n.vdbAddedToRepository, vdbArtifact.getArtifactName()));
-
-        return vdbArtifact;
     }
 
     /**

--- a/komodo-shell/src/main/java/org/komodo/shell/command/CommandException.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/CommandException.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell.command;
+
+import org.komodo.common.i18n.I18n;
+import org.komodo.shell.ShellI18n;
+
+/**
+ * An error running a command.
+ */
+@SuppressWarnings( "serial" )
+class CommandException extends Exception {
+
+    /**
+     * @param command the command where the error occurred (cannot be <code>null</code>)
+     * @param message the error message (can be <code>null</code> or empty)
+     */
+    CommandException(final KomodoCommand<?> command,
+                     final String message) {
+        this(command, message, null);
+    }
+
+    /**
+     * @param command the command where the error occurred (cannot be <code>null</code>)
+     * @param message the error message (can be <code>null</code> or empty)
+     * @param error the error (can be <code>null</code>)
+     */
+    CommandException(final KomodoCommand<?> command,
+                     final String message,
+                     final Throwable error) {
+        super(I18n.bind(ShellI18n.commandError, command.getClass().getSimpleName(), message), error);
+    }
+
+}

--- a/komodo-shell/src/main/java/org/komodo/shell/command/GetVdbCommand.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/GetVdbCommand.java
@@ -8,18 +8,19 @@
 package org.komodo.shell.command;
 
 import org.komodo.common.i18n.I18n;
-import org.komodo.common.util.Precondition;
+import org.komodo.common.util.CollectionUtil;
 import org.komodo.common.util.StringUtil;
 import org.komodo.repository.SoaRepository;
 import org.komodo.repository.artifact.Artifact;
 import org.komodo.repository.artifact.ArtifactResultSet;
 import org.komodo.repository.artifact.teiid.VdbArtifact;
 import org.komodo.shell.ShellI18n;
+import org.komodo.teiid.model.vdb.Vdb;
 
 /**
  * A shell command that finds all VDBs in a repository with a matching name and version. 
  */
-public class GetVdbCommand extends KomodoCommand {
+public class GetVdbCommand extends KomodoCommand<ArtifactResultSet> {
 
     /**
      * The unqualified name of the get VDB command. Value is {@value}.
@@ -40,15 +41,29 @@ public class GetVdbCommand extends KomodoCommand {
         super(cancelable);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.command.KomodoCommand#doExecute(java.lang.String[])
+     */
     @Override
-    protected Object doExecute(final String... args) throws Exception {
-        Precondition.notNull(args, "args"); //$NON-NLS-1$
-        Precondition.notEmpty(args[0], "vdbName"); //$NON-NLS-1$
-        Precondition.notEmpty(args[1], "version"); //$NON-NLS-1$
+    protected ArtifactResultSet doExecute(String... args) throws Exception {
+        // check for incorrect number of args
+        if (CollectionUtil.isEmpty(args) || (args.length > 2)) {
+            throw new InvalidNumberArgsException(this, (CollectionUtil.isEmpty(args) ? 0 : args.length));
+        }
+
+        // add in default version if necessary
+        if (args.length == 1) {
+            args = new String[] {args[0], Vdb.DEFAULT_VERSION};
+        }
+
+        assert (args.length == 2);
 
         this.logger.debug("executing '{}' with cancelable '{}' and params '{}'", new Object[] {getClass().getSimpleName(), //$NON-NLS-1$
             isCancelable(), StringUtil.createDelimitedString(args)});
 
+        final SoaRepository repository = getRepository();
         final String vdbName = args[0];
         final String version = args[1];
 
@@ -56,13 +71,6 @@ public class GetVdbCommand extends KomodoCommand {
         settings.artifactType = VdbArtifact.TYPE;
         settings.params.put(Artifact.Property.NAME, vdbName);
         settings.params.put(Artifact.Property.VERSION, version);
-
-        final SoaRepository repository = getRepository();
-
-        if (repository == null) {
-            print(ShellI18n.connectionNotFound);
-            return ERROR;
-        }
 
         final ArtifactResultSet results = repository.query(settings);
 

--- a/komodo-shell/src/main/java/org/komodo/shell/command/InvalidNumberArgsException.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/InvalidNumberArgsException.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell.command;
+
+import org.komodo.common.i18n.I18n;
+import org.komodo.shell.ShellI18n;
+
+/**
+ * An error when the number of arguments passed to a command is invalid.
+ */
+@SuppressWarnings( "serial" )
+class InvalidNumberArgsException extends Exception {
+
+    InvalidNumberArgsException(final KomodoCommand<?> command,
+                               final int numberOfArgs) {
+        super(I18n.bind(ShellI18n.invalidNumberCommandArgs, command.getClass().getSimpleName(), numberOfArgs));
+    }
+
+}

--- a/komodo-shell/src/main/java/org/komodo/shell/command/KomodoCommandProvider.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/KomodoCommandProvider.java
@@ -37,7 +37,7 @@ public class KomodoCommandProvider implements ShellCommandProvider {
     public Map<String, Class<? extends ShellCommand>> provideCommands() {
         final Map<String, Class<? extends ShellCommand>> commands = new HashMap<String, Class<? extends ShellCommand>>();
         commands.put(AddVdbCommand.NAME, AddVdbCommand.class);
-        commands.put(ConnectKomodoCommand.NAME, ConnectKomodoCommand.class);
+        commands.put(ConnectCommand.NAME, ConnectCommand.class);
         commands.put(GetVdbCommand.NAME, GetVdbCommand.class);
         return commands;
     }

--- a/komodo-shell/src/main/java/org/komodo/shell/command/RepositoryNotFoundException.java
+++ b/komodo-shell/src/main/java/org/komodo/shell/command/RepositoryNotFoundException.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell.command;
+
+import org.komodo.common.i18n.I18n;
+import org.komodo.repository.SoaRepository;
+import org.komodo.shell.ShellI18n;
+
+/**
+ * An error when the command needs a {@link SoaRepository repository} and one can't be found.
+ */
+@SuppressWarnings( "serial" )
+class RepositoryNotFoundException extends Exception {
+
+    RepositoryNotFoundException(final KomodoCommand<?> command) {
+        super(I18n.bind(ShellI18n.repositoryNotFound, command.getClass().getSimpleName()));
+    }
+
+}

--- a/komodo-shell/src/main/resources/org/komodo/shell/ShellI18n.properties
+++ b/komodo-shell/src/main/resources/org/komodo/shell/ShellI18n.properties
@@ -1,24 +1,38 @@
-addVdbCommandHelp = The 'addVdb' command adds a VDB to the Komodo repository.\nExample usage:\n>  komodo:addVdb /Users/elvis/myvdb.xml
-addVdbCommandUsage = komodo:addVdb [path-to-vdb]
+addVdbCommandHelp = The 'addVdb' command adds a VDB to the Komodo repository. A repository connection is required (see 'connect' command).\nExample usage:\n>  komodo:addVdb /Users/elvis/myvdb.xml
+addVdbCommandUsage = komodo:addVdb <path-to-vdb>
 
 # 1 = command name
-commandError = Error running command '%s'
+commandCanceled = Command '%s' was canceled
 
-connectionNotFound = Please connect to a Komodo S-RAMP server using connectKomodo [url] before executing this command.
-connectKomodoCommandHelp = The 'connect' command creates a connection to a remote\nS-RAMP repository at its Atom endpoint using a Komodo client.\nExample usage:\n>  komodo:connectKomodo http://localhost:8080/s-ramp-server
-connectKomodoCommandUsage = komodo:connect [server-url]
+# 1 = command name, 2 = error message
+commandError = Error running command '%s': '%s'
+
+connectKomodoCommandHelp = The 'connect' command creates a connection to a remote S-RAMP repository at its Atom endpoint using a Komodo client.\nExample usage:\n>  komodo:connect http://localhost:8080/s-ramp-server\n>  komodo:connect
+connectKomodoCommandUsage = komodo:connect [<server-url>]
+
+# 1 = file name
+errorAddingVdb = Error running 'AddVdbCommand' for VDB file '%s'
 
 # 1 = file name
 failedToOpenStream = A stream at '%s' could not be opened.
 
-getVdbCommandHelp = The 'getVdb' queries for a VDB and version in a Komodo repository.\nExample usage:\n>  komodo:getVdb MyVdb 1
-getVdbCommandUsage = komodo:getVdb [vdb-name] [vdb-version]
+getVdbCommandHelp = The 'getVdb' queries the Komodo repository for VDB artifacts with a matching name and, optionally, a matching version. A repository connection is required (see 'connect' command).\nExample usage:\n>  komodo:getVdb MyVdb 1\n>  komodo:getVdb MyVdb
+getVdbCommandUsage = komodo:getVdb <vdb-name> [<vdb-version>]
+
+# 1 = command name, 2 = number or incorrect args
+invalidNumberCommandArgs = The '%s' command cannot be run with '%s' arguments.
 
 # 1 = number of VDBs found, 2 = VDB name, 3 = version
 matchingVdbsFoundInRepository = There are '%s' VDBs with a name of '%s' and version of '%s' found in the repository.
 
 # 1 = VDB name, 2 = VDB version
 noMatchingVdbsFoundInRepository = There are no matching VDBs with a name of '%s' and version of '%s' found in the repository.
+
+# 1 = command name
+repositoryCacheNotFound = A SOA repositories cache was not found for the '%s' command.
+
+# 1 = command name
+repositoryNotFound = A connection to a repository is required to execute the '%s' command. Establish a connection by using the 'komodo:connect' command.
 
 # 1 = S-RAMP URL
 successfulConnection = Successfully connected to S-RAMP Komodo endpoint: '%s'

--- a/komodo-shell/src/test/java/org/komodo/shell/command/AddVdbCommandTest.java
+++ b/komodo-shell/src/test/java/org/komodo/shell/command/AddVdbCommandTest.java
@@ -8,17 +8,19 @@
 package org.komodo.shell.command;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
+import org.komodo.repository.artifact.Artifact;
 import org.komodo.repository.artifact.teiid.VdbArtifact;
 
 /**
  * A test class of a {@link AddVdbCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddVdbCommandTest extends ShellCommandTest {
+public class AddVdbCommandTest extends ShellCommandTest<Artifact> {
 
-    private KomodoCommand command;
+    private AddVdbCommand command;
 
     /**
      * {@inheritDoc}
@@ -26,7 +28,7 @@ public class AddVdbCommandTest extends ShellCommandTest {
      * @see org.komodo.shell.command.ShellCommandTest#getCommand()
      */
     @Override
-    protected KomodoCommand getCommand() {
+    protected AddVdbCommand getCommand() {
         if (this.command == null) {
             this.command = new AddVdbCommand();
         }
@@ -36,9 +38,30 @@ public class AddVdbCommandTest extends ShellCommandTest {
 
     @Test
     public void shouldAddTwitterVdb() throws Exception {
-        this.command.doExecute(getFileName("vdb/twitterVdb.xml"));
+        // run command
+        final Artifact result = this.command.doExecute(getFileName("vdb/twitterVdb.xml"));
+
+        // verify result
+        assertThat(result, is(notNullValue()));
+
+        // verify in repo
         this.settings.artifactType = VdbArtifact.TYPE;
         assertThat(_repository.query(this.settings).size(), is(1));
+    }
+
+    @Test( expected = InvalidNumberArgsException.class )
+    public void shouldHaveErrorIfMoreThanOneArg() throws Exception {
+        this.command.doExecute("one", "two");
+    }
+
+    @Test( expected = InvalidNumberArgsException.class )
+    public void shouldHaveErrorIfNoArgs() throws Exception {
+        this.command.doExecute();
+    }
+
+    @Test( expected = CommandException.class )
+    public void shouldHaveErrorIfVdbNotFound() throws Exception {
+        this.command.doExecute("bogusPath");
     }
 
 }

--- a/komodo-shell/src/test/java/org/komodo/shell/command/ConnectCommandTest.java
+++ b/komodo-shell/src/test/java/org/komodo/shell/command/ConnectCommandTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.shell.command;
+
+import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import java.net.UnknownHostException;
+import org.junit.Test;
+import org.komodo.repository.SoaRepository;
+
+/**
+ * A test class of a {@link ConnectCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public class ConnectCommandTest extends ShellCommandTest<SoaRepository> {
+
+    private ConnectCommand command;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.command.ShellCommandTest#getCommand()
+     */
+    @Override
+    protected ConnectCommand getCommand() {
+        if (this.command == null) {
+            this.command = new ConnectCommand();
+        }
+
+        return this.command;
+    }
+
+    @Test( expected = InvalidNumberArgsException.class )
+    public void shouldHaveErrorIfMoreThanOneArg() throws Exception {
+        this.command.doExecute("one", "two");
+    }
+
+    @Test
+    public void shouldAllowNoArgs() throws Exception {
+        final SoaRepository repository = this.command.doExecute();
+        assertNotNull(repository);
+    }
+
+    @Test
+    public void shouldHaveErrorIfRepositoryNotFound() {
+        Throwable cause = null;
+
+        try {
+            this.command.doExecute("bogusRepositoryUrl");
+        } catch (Throwable e) {
+            cause = e;
+            while (cause != null) {
+                if (cause instanceof UnknownHostException) {
+                    break;
+                }
+
+                cause = cause.getCause();
+            }
+        }
+
+        assertThat(cause, is(instanceOf(UnknownHostException.class)));
+    }
+
+}

--- a/komodo-shell/src/test/java/org/komodo/shell/command/KomodoCommandTest.java
+++ b/komodo-shell/src/test/java/org/komodo/shell/command/KomodoCommandTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 @SuppressWarnings( {"javadoc"} )
 public class KomodoCommandTest extends ShellCommandTest {
 
-    private class TestCommand extends KomodoCommand {
+    private class TestCommand extends KomodoCommand<Boolean> {
 
         TestCommand() {
             super();
@@ -33,7 +33,7 @@ public class KomodoCommandTest extends ShellCommandTest {
          * @see org.komodo.shell.command.KomodoCommand#doExecute(java.lang.String[])
          */
         @Override
-        protected Object doExecute(final String... args) throws Exception {
+        protected Boolean doExecute(final String... args) throws Exception {
             if (isCancelable()) {
                 Thread.sleep(1000);
             }
@@ -63,7 +63,7 @@ public class KomodoCommandTest extends ShellCommandTest {
 
     }
 
-    private static final Object RESULT = new Object();
+    private static final Boolean RESULT = Boolean.TRUE;
 
     private KomodoCommand command;
 
@@ -81,13 +81,13 @@ public class KomodoCommandTest extends ShellCommandTest {
         return this.command;
     }
 
-    @Test
+    @Test( expected = InterruptedException.class )
     public void shouldHaveCanceledResultWhenStopped() throws Exception {
         final KomodoCommand cmd = new TestCommand(true);
         cmd.setWaitTime(20L);
         cmd.execute();
         cmd.stop();
-        assertThat(cmd.getResult(), is(KomodoCommand.CANCELED));
+        cmd.getResult();
     }
 
     @Test
@@ -97,7 +97,7 @@ public class KomodoCommandTest extends ShellCommandTest {
 
     @Test
     public void shouldHaveExpectedResultWhenNotStopped() throws Exception {
-        final KomodoCommand cmd = new TestCommand(true);
+        final TestCommand cmd = new TestCommand(true);
         cmd.setWaitTime(20L);
         cmd.execute();
         assertThat(cmd.getResult(), is(RESULT));

--- a/komodo-shell/src/test/java/org/komodo/shell/command/ShellCommandTest.java
+++ b/komodo-shell/src/test/java/org/komodo/shell/command/ShellCommandTest.java
@@ -18,12 +18,12 @@ import org.overlord.sramp.shell.api.SimpleShellContext;
  * The base class for Komodo S-RAMP shell command tests.
  */
 @SuppressWarnings( {"javadoc"} )
-public abstract class ShellCommandTest extends SrampTest implements ShellConstants {
+public abstract class ShellCommandTest<T> extends SrampTest implements ShellConstants {
 
     protected ShellContext context;
     protected SoaRepository.QuerySettings settings;
 
-    protected abstract KomodoCommand getCommand();
+    protected abstract KomodoCommand<T> getCommand();
 
     protected String getFileName(final String projectRelativePathToResource) {
         return getClass().getClassLoader().getResource(projectRelativePathToResource).getFile();
@@ -34,7 +34,9 @@ public abstract class ShellCommandTest extends SrampTest implements ShellConstan
         this.settings = new SoaRepository.QuerySettings();
 
         this.context = new SimpleShellContext();
-        this.context.setVariable(KOMODO_REPOSITORY_QNAME, _repository);
+        this.context.setVariable(SOA_REPOSITORIES, _repositories);
+        this.context.setVariable(CONNECTED_SOA_REPOSITORY, _repository);
+        this.context.setVariable(DEFAULT_REPOSITORY_URL, _repository.getUrl());
         getCommand().setContext(this.context);
     }
 


### PR DESCRIPTION
TEIIDDES-1583 Shell Commands Should Print Usage Details When Wrong Number Of Arguments
TEIIDDES-1585 Artifact Type Identifiers For ImportVdb and Entry Are Switched
TEIIDDES-1589 Change Komodo Shell Command Base Class To Generic Typed By Result Type
Shell commands are now generics and return a specific result based on the command. Also commands now throw exceptions when an invalid number or args are entered. Any other exception is either thrown or wrappted by the command impls now. Some work on test framework. Corrected the artifact types for entry and import VDB. Command usage is printed out now when wrong number of parameters are given to the command. Cancelable commands do not write to System.out any longer.
