### PR TITLE
teiiddes-1560: 

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/actions/GenerateRestWarAction.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/actions/GenerateRestWarAction.java
@@ -14,6 +14,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -364,6 +365,8 @@ public class GenerateRestWarAction extends Action implements ISelectionListener,
                                                 String fullName,
                                                 List restfulProcedureArray ) {
         String restMethod = getRestMethod(procedure);
+        LinkedList<String> queryParameterList = new LinkedList<String>();
+        
 
         if (restMethod != null) {
             String uri = getUri(procedure);
@@ -391,6 +394,7 @@ public class GenerateRestWarAction extends Action implements ISelectionListener,
 
                 }
 
+                //Check for URI parameters
                 String uriString = uri;
                 for (int i = 0; i < uriString.length(); i++) {
                     String character = uriString.substring(i, i + 1);
@@ -399,11 +403,26 @@ public class GenerateRestWarAction extends Action implements ISelectionListener,
                     }
                 }
                 
+                //Check for query parameters
+                if (uriString.indexOf("&")>-1){ //$NON-NLS-1$
+                	String[] queryParameterArray = uriString.split("&"); //$NON-NLS-1$
+	                int i = 0;
+                	for (String param : queryParameterArray) {
+	                	i++;
+                		if (i==1) {
+                			uri= param; //Set the first token as our URI and continue
+                		    continue; 
+                		}
+	                    queryParameterList.addLast(param);
+	                }
+                }
+                
                 restProcedure.setCharSet(charSet);
                 restProcedure.setRestMethod(restMethod);
                 restProcedure.setUri(uri);
                 restProcedure.setProcedureName(name);
                 restProcedure.setFullyQualifiedProcedureName(fullName);
+                restProcedure.setQueryParameterList(queryParameterList);
 
                 // Create JSON version
                 RestProcedure jsonRestProcedure = new RestProcedure();
@@ -413,13 +432,13 @@ public class GenerateRestWarAction extends Action implements ISelectionListener,
                 jsonRestProcedure.setProcedureName(restProcedure.getProcedureName());
                 jsonRestProcedure.setRestMethod(restProcedure.getRestMethod());
                 jsonRestProcedure.setUri(restProcedure.getUri());
-
+          
                 // If the parameterCount is greater than the number of parameters passed
                 // on the URI, we can expect more parameters via an input stream
                 // so the consumes annotation will need to be set. We will set for XML and JSON methods.
-
                 boolean hasInputStream = false;
-                if (uriParameterCount < parameterCount) {
+                if (uriParameterCount != parameterCount &&
+                	queryParameterList.size() != parameterCount) {
                     hasInputStream = true;
                     restProcedure.setConsumesAnnotation("@Consumes( MediaType.APPLICATION_XML )"); //$NON-NLS-1$
                     jsonRestProcedure.setConsumesAnnotation("@Consumes( MediaType.APPLICATION_JSON )"); //$NON-NLS-1$

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/wizards/webservices/util/RestProcedure.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/wizards/webservices/util/RestProcedure.java
@@ -7,6 +7,8 @@
  */
 package org.teiid.designer.runtime.ui.wizards.webservices.util;
 
+import java.util.LinkedList;
+
 /**
  * Domain class that defines a procedure to be exposed RESTFully. This class is used to generate the REST resource class in the
  * generated REST war.
@@ -23,6 +25,7 @@ public class RestProcedure {
     private String uri;
     private String modelName;
     private String charSet;
+    private LinkedList<String> queryParameterList;
 
     /**
      * @return consumesAnnotation
@@ -137,5 +140,21 @@ public class RestProcedure {
     public void setUri( String uri ) {
         this.uri = uri;
     }
+
+	/**
+	 * @return the queryParameterList
+	 * @since 8.1
+	 */
+	public LinkedList<String> getQueryParameterList() {
+		return queryParameterList;
+	}
+
+	/**
+	 * @param queryParameterList the queryParameterList to set
+	 * @since 8.1
+	 */
+	public void setQueryParameterList(LinkedList<String> queryParameterList) {
+		this.queryParameterList = queryParameterList;
+	}
 
 }

--- a/plugins/org.teiid.designer.webservice/rest_war_resources/webapps/WEB-INF/classes/org/teiid/rest/services/ResourceTemplate.java
+++ b/plugins/org.teiid.designer.webservice/rest_war_resources/webapps/WEB-INF/classes/org/teiid/rest/services/ResourceTemplate.java
@@ -31,6 +31,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;


### PR DESCRIPTION
Added query parameter support to the generated REST war. Query parameters can be specified by adding them to the end of a REST procedures URI property with a "&" delimiter. For example: REST:URI = authors&parm1&parm2.
