### PR TITLE
teiiddes-1498: 

### DIFF
--- a/plugins/org.teiid.designer.webservice/src/org/teiid/designer/webservice/gen/BasicWsdlGenerator.java
+++ b/plugins/org.teiid.designer.webservice/src/org/teiid/designer/webservice/gen/BasicWsdlGenerator.java
@@ -1017,7 +1017,7 @@ public class BasicWsdlGenerator implements IWsdlGenerator {
             soapBinding.setStyle(SoapStyleType.DOCUMENT_LITERAL);
             soapBinding.setTransport("http://schemas.xmlsoap.org/soap/http"); //$NON-NLS-1$
             this.binding.setSoapBinding(soapBinding);
-
+         
             // --------------------------------------------------------------------------------------------------------
             // Port information
             // --------------------------------------------------------------------------------------------------------
@@ -1068,7 +1068,7 @@ public class BasicWsdlGenerator implements IWsdlGenerator {
 
             // Add the SOAP operation information ...
             final SoapOperation soapOp = this.soapFactory.createSoapOperation();
-            final String action = CoreStringUtil.Constants.EMPTY_STRING;
+            final String action = opName;
             soapOp.setAction(action);
             addToOperationToProcedureMap(object);
             soapOp.setStyle(SoapStyleType.DOCUMENT_LITERAL);

--- a/plugins/org.teiid.designer.webservice/war_resources/webapps/WEB-INF/classes/org/teiid/soap/provider/TeiidWSProvider.java
+++ b/plugins/org.teiid.designer.webservice/war_resources/webapps/WEB-INF/classes/org/teiid/soap/provider/TeiidWSProvider.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,6 +31,7 @@ import javax.xml.namespace.QName;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPFactory;
 import javax.xml.soap.SOAPFault;
+import javax.xml.soap.SOAPMessage;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -271,11 +273,9 @@ public class TeiidWSProvider {
 		javax.xml.transform.Source response = null; 
 		String inputMessage = ""; //$NON-NLS-1$
 		String procedureName = ""; //$NON-NLS-1$
-		Object wsdlOperationQName = webServiceContext.getMessageContext().get(
-				MessageContext.WSDL_OPERATION);    
-		MessageContext mc = webServiceContext.getMessageContext();   
-		System.out.print(mc.values().toString()); 
-
+		MessageContext mc = webServiceContext.getMessageContext();
+		Object wsdlOperationQName = mc.get(MessageContext.WSDL_OPERATION);  
+		
 		// Load the properties object
 		try {
 			loadProperties();


### PR DESCRIPTION
The operation name was not present in the provider when there were no parameters. Added the soapAction attribute to the soap:operation node of the WSDL which causes CFX to add the operation property to the message and allows the provider to discover it.
