### PR TITLE
TEIIDDES-1717 Allows alternate file extensions in Flat File Importer

### DIFF
--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/query/proc/ITeiidMetadataFileInfo.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/query/proc/ITeiidMetadataFileInfo.java
@@ -140,6 +140,12 @@ public interface ITeiidMetadataFileInfo extends ITeiidFileInfo, ISQLConstants {
     int getNumberOfLinesInFile();
 
     /**
+     * 
+     * @return the Data file filter, if specified
+     */
+    String getDataFileFilter();
+    
+    /**
      * Returns the current generated SQL string based on an unknown relational model name
      * @return the generated SQL string
      */

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/i18n.properties
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/i18n.properties
@@ -808,6 +808,7 @@ TeiidMetadataImportSourcePage.sourceLocation=Location:
 TeiidMetadataImportSourcePage.noProjectOpenMessage=No open projects in workspace
 TeiidMetadataImportSourcePage.sourceModelDefinitionGroup=Source Model Definition
 TeiidMetadataImportSourcePage.folderLocation=Folder location:
+TeiidMetadataImportSourcePage.fileFilterLabel=File Filter:
 TeiidMetadataImportSourcePage.selectedXmlFile=Selected Data File:
 TeiidMetadataImportSourcePage.location=Location:
 TeiidMetadataImportSourcePage.browse=...
@@ -834,6 +835,8 @@ TeiidMetadataImportSourcePage.invalidXmlConnectionProfileTitle=Invalid XML Conne
 TeiidMetadataImportSourcePage.malformedUrlErrorTitle=Malformed URL Error
 TeiidMetadataImportSourcePage.malformedUrlErrorMessage=Error building URL from [{0}]  {1}
 TeiidMetadataImportSourcePage.parsingErrorTitle=XML File Parsing Error
+TeiidMetadataImportSourcePage.noConnectionProfileSelected = Please select a Data File Source
+TeiidMetadataImportSourcePage.invalidXmlFileConnProfileMesage = The Data File Source does not reference a valid XML file
 
 TeiidMetadataImportFormatPage.title=Flat File Column Format Definition
 TeiidMetadataImportFormatPage.messageTitle=Select Column Format For Data File {0}
@@ -896,6 +899,8 @@ TeiidMetadataImportOptionsPage.columnOptionsGroup=Column Options
 TeiidMetadataImportOptionsPage.createColumnActionLabel=Add Column
 TeiidMetadataImportOptionsPage.editTextTableOptionsButtonLabel=Edit TEXTTABLE() function options
 TeiidMetadataImportOptionsPage.editDelimiterButtonLabel=Edit Delimiter Character
+TeiidMetadataImportOptionsPage.sqlUseSelectedFile=Selected File Only
+TeiidMetadataImportOptionsPage.sqlUseSelectedFilter=Use Specified File Filter
 
 DelimiterOptionsDialog.title=Select Delimiter Character
 DelimiterOptionsDialog.titleMessage=Select delimiter type or specify custom using 'Other' option.

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidFileInfo.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidFileInfo.java
@@ -21,10 +21,12 @@ import org.teiid.designer.query.proc.ITeiidFileInfo;
  */
 public abstract class TeiidFileInfo implements ITeiidFileInfo {
 	boolean isFlatFile = false;
+	String dataFileFilter;
 	
 	/**
-	 * 
+	 * Constructor
 	 * @param dataFile the Teiid-formatted data file
+	 * @param isFlatFile 'true' if this is flatFile or 'false' for Xml
 	 */
 	public TeiidFileInfo(File dataFile, boolean isFlatFile) {
 		super();
@@ -56,6 +58,21 @@ public abstract class TeiidFileInfo implements ITeiidFileInfo {
 	 */
 	public File getDataFile() {
 		return this.dataFile;
+	}
+	
+	/**
+	 * 
+	 * @return the Data file filter
+	 */
+	public String getDataFileFilter() {
+		return this.dataFileFilter;
+	}
+	
+	/**
+	 * @param filter the filter string
+	 */
+	public void setDataFileFilter(String filter) {
+		this.dataFileFilter=filter;
 	}
 	
 	/**

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportFormatPage.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportFormatPage.java
@@ -161,6 +161,8 @@ public class TeiidMetadataImportFormatPage extends AbstractWizardPage implements
 	}
 
 	private boolean validatePage() {
+		if(dataFileInfo==null) return false;
+		
 		if( !dataFileInfo.getStatus().isOK() && !(dataFileInfo.getStatus().getSeverity() == IStatus.WARNING)  ) {
 			setThisPageComplete(dataFileInfo.getStatus().getMessage(), IStatus.ERROR);
 			return false;
@@ -176,6 +178,8 @@ public class TeiidMetadataImportFormatPage extends AbstractWizardPage implements
 
 	private void synchronizeUI() {
 		synchronizing = true;
+
+		if(dataFileInfo==null) return;
 
 		String charset = this.info.getFileInfo(this.dataFileInfo.getDataFile()).getCharset();
 		if (!charset.equals(this.dataFileInfo.getCharset())) {

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportInfo.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportInfo.java
@@ -108,6 +108,7 @@ public class TeiidMetadataImportInfo implements UiConstants {
 	private IStatus NO_FILES_STATUS;
 	
 	private int fileMode;
+	private String fileFilterText;
 	
 	/**
 	 * Basic constructor
@@ -416,6 +417,22 @@ public class TeiidMetadataImportInfo implements UiConstants {
 	
 	public int getFileMode() {
 		return this.fileMode;
+	}
+	
+	/**
+	 * Set the filter text
+	 * @param filterText the filter
+	 */
+	public void setFileFilterText(String filterText) {
+		this.fileFilterText=filterText;
+	}
+	
+	/**
+	 * Get the filter text
+	 * @return the filter text
+	 */
+	public String getFileFilterText() {
+		return this.fileFilterText;
 	}
 	
     /**

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportOptionsPage.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/TeiidMetadataImportOptionsPage.java
@@ -95,7 +95,8 @@ public class TeiidMetadataImportOptionsPage  extends AbstractWizardPage implemen
 	StackLayout stackLayout;
 	
 	Text selectedFileText;
-	
+
+	Button useFileTextRadio, useFilterTextRadio;
 	TextViewer sqlTextViewer;
 	IDocument sqlDocument;
 	
@@ -192,6 +193,8 @@ public class TeiidMetadataImportOptionsPage  extends AbstractWizardPage implemen
 
 				loadFileContentsViewers();
 			}
+			this.useFileTextRadio.setSelection(true);
+			this.useFilterTextRadio.setSelection(false);
 			synchronizeUI();
 			
 			validatePage();
@@ -215,6 +218,8 @@ public class TeiidMetadataImportOptionsPage  extends AbstractWizardPage implemen
 	private void synchronizeUI() {
 		synchronizing = true;
 
+		if(dataFileInfo==null) return;
+		
 		selectedFileText.setText(dataFileInfo.getDataFile().getName());
 
 		boolean isDelimitedOption = this.dataFileInfo.doUseDelimitedColumns();
@@ -1066,6 +1071,37 @@ public class TeiidMetadataImportOptionsPage  extends AbstractWizardPage implemen
     	gd.horizontalSpan = 2;
     	textTableOptionsGroup.setLayoutData(gd);
     	
+    	// Radio Button Panel
+    	Composite radioPanel = new Composite(textTableOptionsGroup,SWT.NONE);
+    	radioPanel.setLayout(new GridLayout(2,false));
+    	GridData gd2 = new GridData(GridData.FILL_HORIZONTAL);
+    	radioPanel.setLayoutData(gd2);
+    	
+    	useFileTextRadio = new Button(radioPanel,SWT.RADIO);
+    	useFileTextRadio.setText(getString("sqlUseSelectedFile")); //$NON-NLS-1$
+        useFileTextRadio.addSelectionListener(new SelectionAdapter() {
+
+            @Override
+            public void widgetSelected(final SelectionEvent event) {
+            	if(useFileTextRadio.getSelection()) {
+            		useFilterTextRadio.setSelection(false);
+            		updateSqlText();
+            	}
+            }
+        });
+    	useFilterTextRadio = new Button(radioPanel,SWT.RADIO);
+    	useFilterTextRadio.setText(getString("sqlUseSelectedFilter")); //$NON-NLS-1$
+    	useFilterTextRadio.addSelectionListener(new SelectionAdapter() {
+
+            @Override
+            public void widgetSelected(final SelectionEvent event) {
+            	if(useFilterTextRadio.getSelection()) {
+            		useFileTextRadio.setSelection(false);
+            		updateSqlText();
+            	}
+            }
+        });
+    	
     	ColorManager colorManager = new ColorManager();
         int styles = SWT.V_SCROLL | SWT.MULTI | SWT.BORDER | SWT.WRAP | SWT.FULL_SELECTION;
 
@@ -1210,6 +1246,17 @@ public class TeiidMetadataImportOptionsPage  extends AbstractWizardPage implemen
     
     void updateSqlText() {
     	if( this.dataFileInfo != null ) {
+    		String fileFilterText = this.info.getFileFilterText();
+    		boolean useFilterTextInSQL = this.useFilterTextRadio.getSelection();
+    		if(useFilterTextInSQL) {
+    			if(fileFilterText!=null) {
+    				this.dataFileInfo.setDataFileFilter(fileFilterText);
+    			} else {
+    				this.dataFileInfo.setDataFileFilter("*.*"); //$NON-NLS-1$
+    			}
+    		} else {
+    			this.dataFileInfo.setDataFileFilter(null);
+    		}
     		if( this.info.getSourceModelName() != null ) {
     			String modelName = this.dataFileInfo.getModelNameWithoutExtension(this.info.getSourceModelName());
     			sqlTextViewer.getDocument().set(dataFileInfo.getSqlString(modelName));


### PR DESCRIPTION
Now allows addition file extensions by using a filter on the wizard page.  Allows user to substitute either the filter or specific file in the generated SQL.  Also fixed several issues with wizard behavior when going back and forth between pages.
