### PR TITLE
TEIIDDES-1694 fix regression fix

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/EditServerAction.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/EditServerAction.java
@@ -8,17 +8,18 @@
 package org.teiid.designer.runtime.ui.server;
 
 import static org.teiid.designer.runtime.ui.DqpUiConstants.UTIL;
-
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.commands.IHandlerListener;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.BaseSelectionListenerAction;
-import org.teiid.designer.core.ModelerCore;
+import org.eclipse.ui.handlers.IHandlerService;
 import org.teiid.designer.runtime.spi.ITeiidServer;
 import org.teiid.designer.runtime.ui.DqpUiPlugin;
+import org.teiid.designer.ui.common.util.UiUtil;
 
 
 /**
@@ -35,13 +36,12 @@ public final class EditServerAction extends BaseSelectionListenerAction implemen
     /**
      * Flag determines if default is being edited, or supplied
      */
-	ITeiidServer serverBeingEdited = null;
-    private boolean editDefault = false;
+	private ITeiidServer serverBeingEdited = null;
 
     /**
-     * The server manager used to create and edit servers.
+     * The shell used to display the dialog that edits and creates servers.
      */
-    private Shell shell;
+    private final Shell shell;
 
     // ===========================================================================================================================
     // Constructors
@@ -49,25 +49,30 @@ public final class EditServerAction extends BaseSelectionListenerAction implemen
 
     /**
      * Default Constructor
+     *
+     * Used when called by the {@link IHandlerService}. Calls to the accompanying command should
+     * provide an {@link Event} when executing the command and reference an {@link ITeiidServer}
+     * in the event's data. Otherwise, the dialog for choosing a server will be displayed.
      */
-    public EditServerAction( ) {
+    public EditServerAction() {
         super(UTIL.getString("editServerActionText")); //$NON-NLS-1$
         setToolTipText(UTIL.getString("editServerActionToolTip")); //$NON-NLS-1$
         setImageDescriptor(DqpUiPlugin.getDefault().getImageDescriptor(DqpUiPlugin.Images.EDIT_SERVER_ICON));
         setEnabled(true);
-        this.shell = getShell();
-        this.editDefault = true;
+
+        // Will throw a RuntimeException if there is no workbench window and thus no shell
+        this.shell = UiUtil.getWorkbenchShellOnlyIfUiThread();
     }
     
     /**
      * @param shell the parent shell used to display the dialog
-     * @param editDefault 'true' will edit the current default, 'false' will show a chooser dialog
      */
-    public EditServerAction( Shell shell, boolean editDefault ) {
-        this();
+    public EditServerAction(Shell shell) {
+        super(UTIL.getString("editServerActionText")); //$NON-NLS-1$
+        setToolTipText(UTIL.getString("editServerActionToolTip")); //$NON-NLS-1$
+        setImageDescriptor(DqpUiPlugin.getDefault().getImageDescriptor(DqpUiPlugin.Images.EDIT_SERVER_ICON));
         setEnabled(false);
         this.shell = shell;
-        this.editDefault = editDefault;
     }
     
     // ===========================================================================================================================
@@ -81,28 +86,24 @@ public final class EditServerAction extends BaseSelectionListenerAction implemen
      */
     @Override
     public void run() {
-    	// Edit the Default server
-    	if(this.editDefault) { 
-    		serverBeingEdited = ModelerCore.getDefaultServer();
-    	// Choose Server to Edit
-    	} else {
-    		serverBeingEdited = RuntimeAssistant.selectServer(this.shell,false);
-    	}
-    	
-    	if(RuntimeAssistant.selectServerWasCancelled()) return;
-    	
-    	if( serverBeingEdited == null ) {
-    	    String title = UTIL.getString("noServerAvailableTitle"); //$NON-NLS-1$
-    	    String message = UTIL.getString("noServerAvailableMessage"); //$NON-NLS-1$
-    	    MessageDialog.openError(this.shell, title, message);
-    	    return;
-    	}
-    	    
-    	DqpUiPlugin.editTeiidServer(serverBeingEdited);
-    }
+        // Server may have already been selected by the action
+        // having its updateSelection called. If it hasn't then find
+        // a server to edit accordingly
+        if(this.serverBeingEdited == null) {
+            // Choose Server to Edit
+            serverBeingEdited = RuntimeAssistant.selectServer(this.shell, false);
+            if(RuntimeAssistant.selectServerWasCancelled())
+                return;
+        }
 
-    private static Shell getShell() {
-    	return DqpUiPlugin.getDefault().getCurrentWorkbenchWindow().getShell();
+        if( serverBeingEdited == null ) {
+            String title = UTIL.getString("noServerAvailableTitle"); //$NON-NLS-1$
+            String message = UTIL.getString("noServerAvailableMessage"); //$NON-NLS-1$
+            MessageDialog.openError(this.shell, title, message);
+            return;
+        }
+
+        DqpUiPlugin.editTeiidServer(serverBeingEdited);
     }
 
     /**
@@ -143,6 +144,17 @@ public final class EditServerAction extends BaseSelectionListenerAction implemen
 
 	@Override
 	public Object execute(ExecutionEvent event) {
+	    // Determine whether the execution event carries an
+	    // SWT event with it and whether its loaded wth a
+	    // ITeiidServer reference.
+	    Object object = event.getTrigger();
+	    if (object instanceof Event) {
+	        Event swtEvent = (Event) object;
+	        Object data = swtEvent.data;
+	        if (data instanceof ITeiidServer)
+	            serverBeingEdited = (ITeiidServer) data;
+	    }
+
         run();
         return null;
 	}

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/RuntimeAssistant.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/RuntimeAssistant.java
@@ -159,7 +159,7 @@ public final class RuntimeAssistant {
      * @param shell the shell used to run the new server wizard
      */
     public static void runEditServerAction( Shell shell ) {
-        EditServerAction action = new EditServerAction(shell, false);
+        EditServerAction action = new EditServerAction(shell);
         action.run();
     }
     

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/views/TeiidServerActionProvider.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/views/TeiidServerActionProvider.java
@@ -418,7 +418,7 @@ public class TeiidServerActionProvider extends CommonActionProvider {
         viewer.addSelectionChangedListener(this.disconnectAction);
 
         // the edit action is only enabled when one server is selected
-        this.editServerAction = new EditServerAction(shell, false);
+        this.editServerAction = new EditServerAction(shell);
         viewer.addSelectionChangedListener(this.editServerAction);
 
         // the new server action is always enabled


### PR DESCRIPTION
- When clicking on a Teiid Server in the ServerView, it should not be
  necessary to display the server selection dialog since the server has
  already been selected using the selection changed listener
- EditServerAction
  - The edit server action should have no knowledge of the default server
    and has no need try and get it itself. In all use-cases it should be
    provided with the server that it is editing.
  - The default constructor is invoked when using the action as a command
    handler. In this case, the server-to-edit is provided by the event's
    data object.
  - Since all use-cases have the server provided, the editDefault flag can
    be removed.
- ModelExplorerResourceNavigator
  - Provide the edit server command with an event containing the server-to-
    be-edited.
