### PR TITLE
Selection issues with link with editor

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/refactor/ObjectDeleteCommand.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/refactor/ObjectDeleteCommand.java
@@ -9,7 +9,6 @@ package org.teiid.designer.core.refactor;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,7 +53,7 @@ public class ObjectDeleteCommand implements RefactorCommand {
     private static final int EXCEPTION_CALCULATING_DEPENDENCIES = 3004;
     private static final int EXCEPTION_DURING_DELETE = 3007;
 
-    private EObject[] objectsToDelete;
+    private List<EObject> objectsToDelete;
     private String objectName;
     private boolean moreThanOneResource = false;
     private boolean deleteArrayContainsNull = false;
@@ -84,23 +83,23 @@ public class ObjectDeleteCommand implements RefactorCommand {
      * @param objects
      *
      */
-    public void setObjectsToDelete( EObject[] objects ) {
+    public void setObjectsToDelete( List<EObject> objects ) {
         this.objectsToDelete = objects;
         this.deleteArrayContainsNull = false;
         this.moreThanOneResource = false;
 
-        if (objects != null && objects.length > 0 && objects[0] != null) {
+        if (objects != null && objects.size() > 0 && objects.get(0) != null) {
             // get the IResource from the first object and set it on the base class
-            Resource firstResource = objects[0].eResource();
+            Resource firstResource = objects.get(0).eResource();
 
             // all objects to delete must be in the same resource
-            if (objects.length > 1) {
-                for (int i = 1; i < objects.length; ++i) {
-                    if (objects[i] == null) {
+            if (objects.size() > 1) {
+                for (EObject eObject : objects) {
+                    if (eObject == null) {
                         deleteArrayContainsNull = true;
                         break;
                     }
-                    if (!objects[i].eResource().equals(firstResource)) {
+                    if (!eObject.eResource().equals(firstResource)) {
                         moreThanOneResource = true;
                         break;
                     }
@@ -109,11 +108,10 @@ public class ObjectDeleteCommand implements RefactorCommand {
         }
 
         // set the object name for labels & messages
-        if (objects.length == 1) {
-            this.objectName = ModelerCore.getModelEditor().getName(objects[0]);
+        if (objects.size() == 1) {
+            this.objectName = ModelerCore.getModelEditor().getName(objects.get(0));
         } else {
-            String objectCount = new Integer(objects.length).toString();
-            this.objectName = ModelerCore.Util.getString("ObjectDeleteCommand.Number_of_objects", objectCount); //$NON-NLS-1$
+            this.objectName = ModelerCore.Util.getString("ObjectDeleteCommand.Number_of_objects", objects.size()); //$NON-NLS-1$
         }
     }
 
@@ -143,7 +141,7 @@ public class ObjectDeleteCommand implements RefactorCommand {
         IStatus status;
         String msg;
 
-        if (this.objectsToDelete == null || this.objectsToDelete.length == 0) {
+        if (this.objectsToDelete == null || this.objectsToDelete.size() == 0) {
             msg = ModelerCore.Util.getString("ObjectDeleteCommand.No_delete_target_selected"); //$NON-NLS-1$
             status = new Status(IStatus.ERROR, PID, ERROR_MISSING_OBJECT, msg, null);
             return status;
@@ -181,7 +179,7 @@ public class ObjectDeleteCommand implements RefactorCommand {
      */
     private ModelResource getModelResource() {
         ModelEditor editor = ModelerCore.getModelEditor();
-        ModelResource modelResource = editor.findModelResource(objectsToDelete[0]);
+        ModelResource modelResource = editor.findModelResource(objectsToDelete.get(0));
         return modelResource;
     }
 
@@ -362,7 +360,7 @@ public class ObjectDeleteCommand implements RefactorCommand {
 
             // Delete the objects
             try {
-                ModelerCore.getModelEditor().delete(Arrays.asList(objectsToDelete), monitor);
+                ModelerCore.getModelEditor().delete(objectsToDelete, monitor);
             } catch (ModelerCoreException e) {
                 final Object[] params = new Object[] {objectName};
                 msg = ModelerCore.Util.getString("ObjectDeleteCommand.Error_attempting_to_delete", params); //$NON-NLS-1$

--- a/plugins/org.teiid.designer.ui.common/src/org/teiid/designer/ui/common/eventsupport/SelectionUtilities.java
+++ b/plugins/org.teiid.designer.ui.common/src/org/teiid/designer/ui/common/eventsupport/SelectionUtilities.java
@@ -58,7 +58,7 @@ public class SelectionUtilities implements UiConstants {
      * @param theSelection the selection whose selected <code>EObject</code>s are being requested
      * @return the selected <code>EObject</code>s or an empty <code>List</code>
      */
-    public static List getSelectedEObjects(ISelection theSelection) {
+    public static List<EObject> getSelectedEObjects(ISelection theSelection) {
         List result = getSelectedObjects(theSelection);
 
         if (!result.isEmpty()) {

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/actions/workers/DeleteWorker.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/actions/workers/DeleteWorker.java
@@ -48,6 +48,7 @@ public class DeleteWorker extends ModelObjectWorker {
     private EObject focusedObject;
     private IStatus status;
     private ObjectDeleteCommand odcDeleteCommand;
+    private List<EObject> selectedObjects;
 
     /**
      * @since 4.2
@@ -125,12 +126,9 @@ public class DeleteWorker extends ModelObjectWorker {
                 createObjectDeleteCommand(); // why is this done here unconditionally? it was already called once
             }
 
-            // get the selected objects
-            EObject[] eobjects = getSelectedEObjects();
-
             try {
                 // run it
-                executeCommand(odcDeleteCommand, eobjects, getTransactionSettings());
+                executeCommand(odcDeleteCommand, selectedObjects, getTransactionSettings());
 
             } finally {
 
@@ -152,34 +150,25 @@ public class DeleteWorker extends ModelObjectWorker {
     }
 
     public void createObjectDeleteCommand() {
-        // get the selected objects
-        EObject[] eobjects = getSelectedEObjects();
-
         // create the Delete command, set the objects on it
         odcDeleteCommand = new ObjectDeleteCommand();
-
-        odcDeleteCommand.setObjectsToDelete(eobjects);
+        odcDeleteCommand.setObjectsToDelete(selectedObjects);
     }
 
-    public EObject[] getSelectedEObjects() {
-
+    /**
+     * Set the selected {@link EObject}s
+     */
+    public void setSelectedObjects() {
         ISelection selection = (ISelection)getSelection();
-        List selectedObjects = SelectionUtilities.getSelectedEObjects(selection);
+        selectedObjects = SelectionUtilities.getSelectedEObjects(selection);
+    }
 
-        EObject[] eobjects = new EObject[selectedObjects.size()];
-        int iCount = 0;
-        Iterator it = selectedObjects.iterator();
-
-        while (it.hasNext()) {
-            EObject eoTemp = (EObject)it.next();
-            eobjects[iCount++] = eoTemp;
-        }
-
-        return eobjects;
+    public List<EObject> getSelectedEObjects() {
+        return selectedObjects;
     }
 
     private void executeCommand( final ObjectDeleteCommand odcDeleteCommand,
-                                 final EObject[] eObjects,
+                                 final List<EObject> eObjects,
                                  TransactionSettings ts ) {
 
         if (odcDeleteCommand == null) {
@@ -187,8 +176,8 @@ public class DeleteWorker extends ModelObjectWorker {
         }
 
         String tempString = UiConstants.Util.getString(DELETE_ONE_TITLE_KEY);
-        if (eObjects.length > 1) {
-            tempString = UiConstants.Util.getString(DELETE_MANY_TITLE_KEY, eObjects.length);
+        if (eObjects.size() > 1) {
+            tempString = UiConstants.Util.getString(DELETE_MANY_TITLE_KEY, eObjects.size());
         }
         final String deleteTitle = tempString;
 
@@ -261,20 +250,20 @@ public class DeleteWorker extends ModelObjectWorker {
 
     private TransactionSettings processDescription( TransactionSettings ts ) {
 
-        ts.setDescription(getUndoText(getSelectedEObjects()));
+        ts.setDescription(getUndoText());
 
         return ts;
     }
 
-    private String getUndoText( EObject[] selectedObjects ) {
+    private String getUndoText() {
 
         String description = null;
-        if (selectedObjects.length == 1) {
-            EObject obj = selectedObjects[0];
+        if (selectedObjects.size() == 1) {
+            EObject obj = selectedObjects.get(0);
             String path = ModelerCore.getModelEditor().getModelRelativePath(obj).toString();
             description = UiConstants.Util.getString(UNDO_TEXT, path);
         } else {
-            description = UiConstants.Util.getString(PLURAL_UNDO_TEXT, selectedObjects.length);
+            description = UiConstants.Util.getString(PLURAL_UNDO_TEXT, selectedObjects.size());
         }
         return description;
     }


### PR DESCRIPTION
- The DeleteWorker assigns the selected objects to the delete command
  during its execution phase. However, during the pre-run phase, the
  model editors associated with the selected objects are opened. If the
  'link with editor' option is selected then the focus on the editor
  causes the selection to change PRIOR to the execution phase.
- DeleteEObjectAction
  - Assigns the selected objects to the DeleteWorker at the start of the
    pre-run phase
- DeleteWorker
  - Caches the selected objects when the set method is called
- Convert multiple uses of arrays into lists
