### PR TITLE
TEIIDDES-1699: Assign Teiid Server unique id

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/util/KeyInValueHashMap.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/util/KeyInValueHashMap.java
@@ -5,7 +5,7 @@
 *
 * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
 */
-package org.teiid.designer.ui.common.util;
+package org.teiid.designer.core.util;
 
 import java.util.AbstractMap;
 import java.util.HashMap;

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/DqpUiPlugin.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/DqpUiPlugin.java
@@ -27,7 +27,6 @@ import org.teiid.core.designer.PluginUtil;
 import org.teiid.core.designer.util.I18nUtil;
 import org.teiid.core.designer.util.PluginUtilImpl;
 import org.teiid.designer.runtime.DqpPlugin;
-import org.teiid.designer.runtime.TeiidServer;
 import org.teiid.designer.runtime.TeiidServerManager;
 import org.teiid.designer.runtime.connection.spi.IPasswordProvider;
 import org.teiid.designer.runtime.preview.jobs.TeiidPreviewVdbCleanupJob;
@@ -256,7 +255,7 @@ public class DqpUiPlugin extends AbstractUiPlugin implements DqpUiConstants {
         IWorkbenchPage page = workbenchWindow.getActivePage();
         
         try {
-            TeiidServerEditorInput input = new TeiidServerEditorInput(server.getUrl());
+            TeiidServerEditorInput input = new TeiidServerEditorInput(server.getId());
             page.openEditor(input, TeiidServerEditor.EDITOR_ID);
         } catch (Exception e) {
             DqpUiConstants.UTIL.log(e);

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditorInput.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditorInput.java
@@ -20,21 +20,21 @@ import org.teiid.designer.runtime.spi.ITeiidServer;
  */
 public class TeiidServerEditorInput implements IEditorInput, IPersistableElement {
 
-    private String serverUrl;
+    private String serverId;
 
     /**
-     * @param serverUrl
+     * @param serverId
      */
-    public TeiidServerEditorInput(String serverUrl) {
-        this.serverUrl = serverUrl;
+    public TeiidServerEditorInput(String serverId) {
+        this.serverId = serverId;
     }
     
     /**
-     * Returns the server url
-     * @return unique url of this server
+     * Returns the server id
+     * @return unique id of this server
      */
-    public String getServerUrl() {
-        return serverUrl;
+    public String getServerId() {
+        return serverId;
     }
     
     /**
@@ -47,7 +47,7 @@ public class TeiidServerEditorInput implements IEditorInput, IPersistableElement
         if (dqpPlugin == null) 
             return null;
         
-        return dqpPlugin.getServerManager().getServer(serverUrl);
+        return dqpPlugin.getServerManager().getServer(serverId);
     }
 
     /**
@@ -60,17 +60,17 @@ public class TeiidServerEditorInput implements IEditorInput, IPersistableElement
         if (!(obj instanceof TeiidServerEditorInput))
             return false;
         TeiidServerEditorInput other = (TeiidServerEditorInput) obj;
-        if (serverUrl == null) {
-            if (other.serverUrl != null)
+        if (serverId == null) {
+            if (other.serverId != null)
                 return false;   
-        } else if (!serverUrl.equals(other.serverUrl))
+        } else if (!serverId.equals(other.serverId))
             return false;
         return true;
     }
 
     @Override
     public boolean exists() {
-        if (serverUrl != null && getTeiidServer() == null)
+        if (serverId != null && getTeiidServer() == null)
             return false;
         
         return true;
@@ -93,12 +93,12 @@ public class TeiidServerEditorInput implements IEditorInput, IPersistableElement
     
     @Override
     public String getName() {
-        if (serverUrl != null) {
+        if (serverId != null) {
             ITeiidServer server = getTeiidServer();
             if (server != null)
                 return server.getCustomLabel();
             
-            return serverUrl;
+            return serverId;
         }
         return ""; //$NON-NLS-1$
     }

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditorInputFactory.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditorInputFactory.java
@@ -18,14 +18,14 @@ public class TeiidServerEditorInputFactory implements IElementFactory {
 
     protected final static String FACTORY_ID = "org.teiid.designer.runtime.ui.server.editor.input.factory"; //$NON-NLS-1$
     
-    protected final static String SERVER_URL = "server-url"; //$NON-NLS-1$
+    protected final static String SERVER_ID = "server-id"; //$NON-NLS-1$
 
     @Override
     public IAdaptable createElement(IMemento memento) {
-        // get the resource names
-        String serverUrl = memento.getString(SERVER_URL);
+        // get the server id from the memento
+        String serverId = memento.getString(SERVER_ID);
         
-        return new TeiidServerEditorInput(serverUrl);
+        return new TeiidServerEditorInput(serverId);
     }
 
     /**
@@ -37,8 +37,8 @@ public class TeiidServerEditorInputFactory implements IElementFactory {
     public static void saveState(IMemento memento, TeiidServerEditorInput input) {
         if (input == null)
             return;
-            
-        if (input.getServerUrl() != null)
-            memento.putString(SERVER_URL, input.getServerUrl());
+
+        if (input.getServerId() != null)
+            memento.putString(SERVER_ID, input.getServerId());
     }
 }

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidServer.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidServer.java
@@ -102,6 +102,11 @@ public class TeiidServer implements ITeiidServer {
     private String host;
 
     /**
+     * The unique id of this server
+     */
+    private final String id;
+
+    /**
      * The parent {@link IServer} of this teiid server
      */
     private IServer parentServer;
@@ -112,6 +117,7 @@ public class TeiidServer implements ITeiidServer {
      * ie. turn off -> do work -> turn on
      */
     private boolean notifyListeners = true;
+
 
     // ===========================================================================================================================
     // Constructors
@@ -151,6 +157,8 @@ public class TeiidServer implements ITeiidServer {
         
         this.eventManager = eventManager;
         this.parentServer = parentServer;
+
+        this.id = getUrl() + "-" + getServerVersion() + "-" + getParent().getId();  //$NON-NLS-1$//$NON-NLS-2$
         
         if (parentServer.getServerState() != IServer.STATE_STARTED)
             disconnect();
@@ -181,12 +189,9 @@ public class TeiidServer implements ITeiidServer {
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         TeiidServer other = (TeiidServer)obj;
-        if (this.admin == null) {
-            if (other.admin != null) return false;
-        } else if (!this.admin.equals(other.admin)) return false;
-        if (this.eventManager == null) {
-            if (other.eventManager != null) return false;
-        } else if (!this.eventManager.equals(other.eventManager)) return false;
+        if (this.id == null) {
+            if (other.id != null) return false;
+        } else if (!this.id.equals(other.id)) return false;
         if (this.host == null) {
             if (other.host != null) return false;
         } else if (!this.host.equals(other.host)) return false;
@@ -281,7 +286,12 @@ public class TeiidServer implements ITeiidServer {
 
         return this.host;
     }
-    
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
     /**
      * @return the parentServer
      */
@@ -302,20 +312,6 @@ public class TeiidServer implements ITeiidServer {
         result = prime * result + ((this.teiidAdminInfo == null) ? 0 : this.teiidAdminInfo.hashCode());
         result = prime * result + ((this.teiidJdbcInfo == null) ? 0 : this.teiidJdbcInfo.hashCode());
         return result;
-    }
-
-    /**
-     * A server has the same identifying properties if their URL and user matches.
-     * 
-     * @param otherServer the server whose key is being compared (never <code>null</code>)
-     * @return <code>true</code> if the servers have the same key
-     * @throws IllegalArgumentException if the argument is <code>null</code>
-     */
-    @Override
-    public boolean hasSameKey( ITeiidServer otherServer ) {
-        CoreArgCheck.isNotNull(otherServer, "otherServer"); //$NON-NLS-1$
-        return (equivalent(getUrl(), otherServer.getUrl()) && equivalent(getTeiidAdminInfo().getUsername(),
-                                                                         otherServer.getTeiidAdminInfo().getUsername()));
     }
 
     /**

--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/ITeiidServer.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/ITeiidServer.java
@@ -56,18 +56,14 @@ public interface ITeiidServer extends IExecutionAdmin, HostProvider {
     String getUrl();
 
     /**
+     * @return the unique identifier of this server
+     */
+    String getId();
+
+    /**
      * @return the parentServer
      */
     IServer getParent();
-
-    /**
-     * A server has the same identifying properties if their URL and user matches.
-     * 
-     * @param otherServer the server whose key is being compared (never <code>null</code>)
-     * @return <code>true</code> if the servers have the same key
-     * @throws IllegalArgumentException if the argument is <code>null</code>
-     */
-    boolean hasSameKey(ITeiidServer otherServer);
 
     /**
      * @return <code>true</code> if a connection to this server exists and is working

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/refactor/AbstractResourcesRefactoring.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/refactor/AbstractResourcesRefactoring.java
@@ -20,8 +20,8 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
-import org.teiid.designer.ui.common.util.KeyInValueHashMap;
-import org.teiid.designer.ui.common.util.KeyInValueHashMap.KeyFromValueAdapter;
+import org.teiid.designer.core.util.KeyInValueHashMap;
+import org.teiid.designer.core.util.KeyInValueHashMap.KeyFromValueAdapter;
 import org.teiid.designer.ui.refactor.RefactorResourcesUtils.AbstractResourceCallback;
 import org.teiid.designer.vdb.refactor.VdbResourceChange;
 

--- a/tests/org.teiid.designer.dqp.test/testdata/oldregistrydata/serverRegistry.xml
+++ b/tests/org.teiid.designer.dqp.test/testdata/oldregistrydata/serverRegistry.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<servers>
-  <server url="mm://localhost:8080" user="user8080"/>
-  <server url="mm://localhost:8180" user="user8180" default="true"/>
-  <server url="mm://localhost:8280" user="user8280"/>
-</servers>

--- a/tests/org.teiid.designer.dqp.test/testdata/serverRegistry.xml
+++ b/tests/org.teiid.designer.dqp.test/testdata/serverRegistry.xml
@@ -4,8 +4,8 @@
     <admin host="localhost" password="YWRtaW4=" port="31443" secure="true" user="admin"/>
     <jdbc jdbchost="localhost" jdbcport="31000" jdbcsecure="false" jdbcuser="teiid"/>
   </server>
-  <server>
-    <admin host="myserver.com" port="31444" secure="false" user="admin2" version="8.2.1-beta1" parentServerId="server2"/>
+  <server version="8.2.1" parentServerId="server2">
+    <admin host="myserver.com" port="31444" secure="false" user="admin2"/>
     <jdbc jdbchost="myserver.com" jdbcpassword="dGVpaWQ=" jdbcport="31001" jdbcsecure="true" jdbcuser="teiid2"/>
   </server>
 </servers>


### PR DESCRIPTION
- Allows servers residing on the same box, with the same host and port
  to be configured in the Servers View
- Move KeyInValueHashMap to a more useful location
- ITeiidServer
  - Provide a getId() method that returns the unique identifier for the server
- TeiidServer
  - Generate the unique id from the url, version and parent id
- TeiidServerManager
  - Cache the servers in a map keyed on the server id rather than a list
  - Get servers using their id rather than their url since the latter is not
    unique
  - Remove the 'old' xml state restoration since it makes little sense and
    would never produce a working teiid server due to a lack of associated
    parent server.
- DqpUiPlugin
- TeiidServerEditorInput[Factory]
  - Use the server's id rather than the url
- ServerManagerTest
  - Fixes tests in light of API and functional changes to server manager
  - Remove testing of old registry xml syntax since it is no longer used
  - Fixes syntax of second server in test registry data xml
