### PR TITLE
TEIIDDES-1654 DDL Importer needs to better handle constraint naming

### DIFF
--- a/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/model/RelationalTable.java
+++ b/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/model/RelationalTable.java
@@ -83,6 +83,7 @@ public class RelationalTable extends RelationalReference {
         this.accessPatterns = new ArrayList<RelationalAccessPattern>();
         this.foreignKeys = new ArrayList<RelationalForeignKey>();
         this.indexes = new ArrayList<RelationalIndex>();
+        this.uniqueConstraints = new ArrayList<RelationalUniqueConstraint>();
         setNameValidator(new RelationalStringNameValidator(true, true));
     }
     

--- a/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/processor/EmfModelGenerator.java
+++ b/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/processor/EmfModelGenerator.java
@@ -354,8 +354,8 @@ public class EmfModelGenerator {
         	pkList.add(new DeferredPair(pk,baseTable));
         }
         
-        RelationalUniqueConstraint uc = tableRef.getUniqueContraint();
-        if( uc != null){
+        Collection<RelationalUniqueConstraint> ucs = tableRef.getUniqueConstraints();
+        for(RelationalUniqueConstraint uc: ucs) {
         	ucList.add(new DeferredPair(uc,baseTable));
         }
         


### PR DESCRIPTION
The ModeShape DDL sequencer is now handling the unique naming of the constraints correctly, so no Designer changes were required for that issue.  However, I ran into a NPE with the UniqueConstraint generation - so this request resolves that issue.
