### PR TITLE
teiiddes-1387: 

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
@@ -29,6 +29,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
@@ -2255,4 +2256,30 @@ public class ModelerCore extends Plugin implements DeclarativeTransactionManager
             throw new RuntimeException(ex);
         }
     }
+    
+    /**
+     * This method will generate a ModelResource based on IPath and and name
+	 * @param location
+	 * @param modelName
+	 * @return
+     * @since 8.2
+	 */
+	public static ModelResource createModelResource(IPath location, String modelName) {
+		IResource resource;
+		IProject project;
+		resource = ModelerCore.getWorkspace().getRoot().findMember(location);
+        
+        if( location.segmentCount() == 1 ) {
+        	//We already have the project
+        	project = (IProject)resource;
+        } else {
+        	//Get the project for a folder(s)
+        	project = resource.getProject();
+        }
+        	
+        IPath relativeModelPath = resource.getFullPath().removeFirstSegments(1).append(modelName);
+        final IFile modelFile = project.getFile( relativeModelPath );
+        final ModelResource resrc = ModelerCore.create( modelFile );
+		return resrc;
+	}
 }

--- a/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/model/RelationalModelFactory.java
+++ b/plugins/org.teiid.designer.relational/src/org/teiid/designer/relational/model/RelationalModelFactory.java
@@ -115,18 +115,7 @@ public class RelationalModelFactory implements RelationalConstants {
      * @throws ModelWorkspaceException if error creating model
      */
     public ModelResource createRelationalModel( IPath location, String modelName) throws ModelWorkspaceException {
-        ModelWorkspaceItem mwItem = null;
-        if( location.segmentCount() == 1 ) {
-        	// Project for ONE segment
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.PROJECT);
-        } else {
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.FOLDER);
-        }
-        
-        IProject project = mwItem.getResource().getProject();
-        IPath relativeModelPath = mwItem.getPath().removeFirstSegments(1).append(modelName);
-        final IFile modelFile = project.getFile( relativeModelPath );
-        final ModelResource resrc = ModelerCore.create( modelFile );
+    	final ModelResource resrc = ModelerCore.createModelResource(location, modelName);
         resrc.getModelAnnotation().setPrimaryMetamodelUri( RELATIONAL_PACKAGE_URI );
         resrc.getModelAnnotation().setModelType(ModelType.PHYSICAL_LITERAL);
         ModelerCore.getModelEditor().getAllContainers(resrc.getEmfResource());

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/FlatFileRelationalModelFactory.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/FlatFileRelationalModelFactory.java
@@ -70,25 +70,14 @@ public class FlatFileRelationalModelFactory implements UiConstants {
     }
     
     public ModelResource createRelationalModel( IPath location, String modelName) throws ModelWorkspaceException {
-        ModelWorkspaceItem mwItem = null;
-        if( location.segmentCount() == 1 ) {
-        	// Project for ONE segment
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.PROJECT);
-        } else {
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.FOLDER);
-        }
-        
-        IProject project = mwItem.getResource().getProject();
-        IPath relativeModelPath = mwItem.getPath().removeFirstSegments(1).append(modelName);
-        final IFile modelFile = project.getFile( relativeModelPath );
-        final ModelResource resrc = ModelerCore.create( modelFile );
+    	final ModelResource resrc = ModelerCore.createModelResource(location, modelName);
         resrc.getModelAnnotation().setPrimaryMetamodelUri( RELATIONAL_PACKAGE_URI );
         resrc.getModelAnnotation().setModelType(ModelType.PHYSICAL_LITERAL);
         ModelUtilities.initializeModelContainers(resrc, "Create Model Containers", this); //$NON-NLS-1$ 
         
         return resrc;
     }
-    
+
     public boolean addMissingProcedure(ModelResource modelResource, String specificProcedure) throws ModelerCoreException{
     	if( modelResource != null ) {
     		if( specificProcedure.equalsIgnoreCase(ALL_PROCEDURES)) {

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/FlatFileViewModelFactory.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/file/FlatFileViewModelFactory.java
@@ -46,23 +46,7 @@ public class FlatFileViewModelFactory extends FlatFileRelationalModelFactory {
     public static final DatatypeManager datatypeManager = ModelerCore.getWorkspaceDatatypeManager();
     
     public ModelResource createViewRelationalModel( IPath location, String modelName) throws ModelWorkspaceException {
-        ModelWorkspaceItem mwItem = null;
-
-        // One Segment -- Project
-        if( location.segmentCount() == 1 ) {
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.PROJECT);
-        } else {
-            // Multiple Segments -- Folder
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.FOLDER);
-        }
-        
-        // Get the Project
-        IProject project = mwItem.getResource().getProject();
-
-        // Create the model at the specified relative path
-        IPath relativeModelPath = mwItem.getPath().removeFirstSegments(1).append(modelName);
-        final IFile modelFile = project.getFile( relativeModelPath );
-        final ModelResource resrc = ModelerCore.create( modelFile );
+    	final ModelResource resrc = ModelerCore.createModelResource(location, modelName);
         resrc.getModelAnnotation().setPrimaryMetamodelUri( RELATIONAL_PACKAGE_URI );
         resrc.getModelAnnotation().setModelType(ModelType.VIRTUAL_LITERAL);
         ModelUtilities.initializeModelContainers(resrc, "Create Model Containers", this); //$NON-NLS-1$ 

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/XmlFileViewModelFactory.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/XmlFileViewModelFactory.java
@@ -54,23 +54,7 @@ public class XmlFileViewModelFactory  extends FlatFileRelationalModelFactory {
     public static final String WIDTH = "width"; //$NON-NLS-1$
     
     public ModelResource createViewRelationalModel( IPath location, String modelName) throws ModelWorkspaceException {
-        ModelWorkspaceItem mwItem = null;
-
-        // One Segment -- Project
-        if( location.segmentCount() == 1 ) {
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.PROJECT);
-        } else {
-            // Multiple Segments -- Folder
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.FOLDER);
-        }
-        
-        // Get the Project
-        IProject project = mwItem.getResource().getProject();
-
-        // Create the model at the specified relative path
-        IPath relativeModelPath = mwItem.getPath().removeFirstSegments(1).append(modelName);
-        final IFile modelFile = project.getFile( relativeModelPath );
-        final ModelResource resrc = ModelerCore.create( modelFile );
+    	final ModelResource resrc = ModelerCore.createModelResource(location, modelName);
         resrc.getModelAnnotation().setPrimaryMetamodelUri( RELATIONAL_PACKAGE_URI );
         resrc.getModelAnnotation().setModelType(ModelType.VIRTUAL_LITERAL);
         ModelUtilities.initializeModelContainers(resrc, "Create Model Containers", this); //$NON-NLS-1$ 

--- a/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/model/RelationalViewModelFactory.java
+++ b/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/model/RelationalViewModelFactory.java
@@ -60,18 +60,7 @@ public class RelationalViewModelFactory extends RelationalModelFactory {
      * @throws ModelWorkspaceException error thrown when problem creating new model
      */
     public ModelResource createRelationalViewModel( IPath location, String modelName) throws ModelWorkspaceException {
-        ModelWorkspaceItem mwItem = null;
-        if( location.segmentCount() == 1 ) {
-        	// Project for ONE segment
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.PROJECT);
-        } else {
-        	mwItem = ModelWorkspaceManager.getModelWorkspaceManager().findModelWorkspaceItem(location.makeAbsolute(), IResource.FOLDER);
-        }
-        
-        IProject project = mwItem.getResource().getProject();
-        IPath relativeModelPath = mwItem.getPath().removeFirstSegments(1).append(modelName);
-        final IFile modelFile = project.getFile( relativeModelPath );
-        final ModelResource resrc = ModelerCore.create( modelFile );
+    	final ModelResource resrc = ModelerCore.createModelResource(location, modelName);
         resrc.getModelAnnotation().setPrimaryMetamodelUri( RELATIONAL_PACKAGE_URI );
         resrc.getModelAnnotation().setModelType(ModelType.VIRTUAL_LITERAL);
         ModelerCore.getModelEditor().getAllContainers(resrc.getEmfResource());


### PR DESCRIPTION
The ModelWorkspaceManager did not contain the newly created project when we tried to add the model resource since this happens when a resource is added. Changed to use ModelerCore.getWorkspace().getRoot().findMember(location) to get the project or project folder. Also broke logic out into a separate method in ModelErCore since this was needed in several classes for view and source models (XML, Flat File, Relational).
