### PR TITLE
TEIIDDES-1775: Centralise the handling of the default server preference

### DIFF
--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
@@ -27,9 +27,6 @@ import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.provider.INotifyChangedListener;
 import org.eclipse.jface.action.Action;
@@ -110,7 +107,6 @@ import org.teiid.designer.runtime.spi.EventManager;
 import org.teiid.designer.runtime.spi.ExecutionConfigurationEvent;
 import org.teiid.designer.runtime.spi.IExecutionConfigurationListener;
 import org.teiid.designer.runtime.spi.ITeiidServer;
-import org.teiid.designer.runtime.spi.ITeiidServerManager;
 import org.teiid.designer.runtime.spi.ITeiidServerVersionListener;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 import org.teiid.designer.ui.PluginConstants;
@@ -286,16 +282,6 @@ public class ModelExplorerResourceNavigator extends ResourceNavigator
         public void configurationChanged(ExecutionConfigurationEvent event) {
             setDefaultServerText(ModelerCore.getDefaultServerName());
             setDefaultServerVersionText(ModelerCore.getTeiidServerVersion());
-        }
-    };
-
-    /* Listen for changes to the default server version preference */
-    private IPreferenceChangeListener preferenceChangeListener = new IPreferenceChangeListener() {
-        @Override
-        public void preferenceChange(PreferenceChangeEvent event) {
-            if (ITeiidServerManager.DEFAULT_TEIID_SERVER_VERSION_ID.equals(event.getKey())) {
-                setDefaultServerVersionText(ModelerCore.getTeiidServerVersion());
-            }
         }
     };
 
@@ -499,9 +485,6 @@ public class ModelExplorerResourceNavigator extends ResourceNavigator
         /* Listen for changes to the default server */
         ModelerCore.addTeiidServerVersionListener(teiidServerVersionListener);
         addExecutionConfigurationListener(ModelerCore.getDefaultServerEventManager());
-
-        IEclipsePreferences prefs = UiPlugin.getDefault().getPreferences();
-        prefs.addPreferenceChangeListener(preferenceChangeListener);
     }
 
     /**
@@ -725,10 +708,6 @@ public class ModelExplorerResourceNavigator extends ResourceNavigator
     public void dispose() {
         // Remove listeners
         ModelerCore.removeTeiidServerVersionListener(teiidServerVersionListener);
-
-        IEclipsePreferences prefs = UiPlugin.getDefault().getPreferences();
-        if (prefs != null)
-            prefs.removePreferenceChangeListener(preferenceChangeListener);
 
         // unhook the selection listeners from the seleciton service
         getViewSite().getWorkbenchWindow().getSelectionService().removeSelectionListener(getModelObjectSelectionListener());

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/i18n.properties
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/i18n.properties
@@ -1544,6 +1544,8 @@ ModelNameChecker.illegalExtensionMessage=Model files must end with the extension
 DefaultTeiidServerPreferenceContributor.name=defaultTeiidServerVersion
 DefaultTeiidServerPreferenceContributor.title=Default Teiid Server Version (applicable if no teiid server defined)
 DefaultTeiidServerPreferenceContributor.toolTip=This selects the last resort default teiid server version to be used for designer modelling if no teiid server has yet been defined in the servers view.
+DefaultTeiidServerPreferenceContributor.versionChangeQuestionTitle=Changing server version
+DefaultTeiidServerPreferenceContributor.versionChangeQuestionMessage=Since no default server is present, this will result in changing the default server version hence closing any open model editors. Are you sure you want to change the server version at this time?
 
 #### RefreshModelAction ####
 RefreshModelAction.updateNotAllowed.title=Source Auto Update Not Allowed


### PR DESCRIPTION
- Rather than the ModelExplorerResourceNavigator listening for the server
  preference change, have the TeiidServerManager deal with it in the same
  manner as a default server change. Ensures that editors can be closed
  if necessary.
- DefaultTeiidServerPreferenceContributor
  - Since editors may be closed as a consequence of the server version
    preference being modified, ask the user if this is acceptable and if
    not then do not apply the change in preference.
  - Sort the runtime version available with the most recent at the top.
- TeiidServerManager
  - Adds the preference listener
  - Run the closeEditors function on the UI thread to avoid any possibility
    of invalid thread access exceptions
