### PR TITLE
TEIIDDES-1502 Failure to access Oracle data source with column names enclosed in double quotes

### DIFF
--- a/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/custom/Db2ModelProcessor.java
+++ b/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/custom/Db2ModelProcessor.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.teiid.designer.jdbc.metadata.JdbcDatabase;
+import org.teiid.designer.jdbc.relational.impl.Context;
 import org.teiid.designer.jdbc.relational.impl.RelationalModelProcessorImpl;
 import org.teiid.designer.metamodels.core.ModelAnnotation;
 import org.teiid.designer.metamodels.relational.RelationalFactory;
@@ -70,11 +71,13 @@ public class Db2ModelProcessor extends RelationalModelProcessorImpl {
                                       String catalogName,
                                       String schemaName,
                                       String tableName,
-                                      List columnNames) {
+                                      List columnNames,
+                                      Context context,
+                                      List<String> problems) {
         // Per defect 13227, the getImportedKeys and getExportedKeys returns a non-null value in the
         // 'catalog' column, even though DatabaseMetaData returns 'false' for supportsCatalogs.
         // Therefore, as a workaround, ignore the catalog name when supportsCatalogs is false ...
-        return super.findUniqueKey(dbNode, nodesToModelObjects, catalogName, schemaName, tableName, columnNames);
+        return super.findUniqueKey(dbNode, nodesToModelObjects, catalogName, schemaName, tableName, columnNames, context, problems);
     }
 
     /** 

--- a/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/custom/ExcelModelProcessor.java
+++ b/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/custom/ExcelModelProcessor.java
@@ -104,7 +104,7 @@ public class ExcelModelProcessor extends RelationalModelProcessorImpl {
             }
 
             // Build a map of the columns by their name so they can be found much more quickly ...
-            final Map columnsByName = createColumnMapKeyedByNames(table);
+            final Map columnsByName = createColumnMapKeyedByNames(table,tableNode,context,problems);
 
             // Go through the results
             boolean hasPrimaryKey = false;


### PR DESCRIPTION
- modified the method "createColumnMapKeyedByNames" which creates the name mapping.
- modified the key lookups to use the name consistent with the map
  It is important to use the NIS as originally coded, because the name matching is done directly against the JDBC (source) name.
