### PR TITLE
TEIIDDES-1742 Creation of multiple non-JDBC sources in Designer requires JBossAS restarts

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/plugin.xml
+++ b/plugins/org.teiid.designer.dqp.ui/plugin.xml
@@ -36,6 +36,12 @@
       </preference>
       <!-- Enable Teiid Preview Cleanup Preference -->
       <preference
+            id="enablePreviewDeleteRASourcesPreferenceContributor"
+            categoryId="dqpUiPreferenceCategory"
+            class="org.teiid.designer.runtime.ui.preferences.EnablePreviewDeleteRASourcesPreferenceContributor">
+      </preference>
+      <!-- Enable Preview Delete of RA Sources Preference -->
+      <preference
             id="enableTeiidPreviewCleanupPreferenceContributor"
             categoryId="dqpUiPreferenceCategory"
             class="org.teiid.designer.runtime.ui.preferences.EnableTeiidPreviewCleanupPreferenceContributor">

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/CreateDataSourceAction.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/CreateDataSourceAction.java
@@ -172,7 +172,11 @@ public class CreateDataSourceAction extends SortableSelectionAction implements D
                                         getString("errorCreatingDataSourceForModel", modelResource.getItemName()), e.getMessage()); //$NON-NLS-1$
                 DqpUiConstants.UTIL.log(IStatus.ERROR, e, getString("errorCreatingDataSourceForModel", modelResource.getItemName())); //$NON-NLS-1$
             } else {
-                MessageDialog.openError(getShell(), getString("errorCreatingDataSource"), e.getMessage()); //$NON-NLS-1$
+            	String msg = e.getMessage();
+            	if(msg!=null && msg.startsWith("TEIID70006 JBAS014749")) { //$NON-NLS-1$
+            		msg = getString("errorDeployingDataSourceTryRestartMsg"); //$NON-NLS-1$
+            	} 
+                MessageDialog.openError(getShell(), getString("errorCreatingDataSource"), msg ); //$NON-NLS-1$
                 DqpUiConstants.UTIL.log(IStatus.ERROR, e, getString("errorCreatingDataSource")); //$NON-NLS-1$
 
             }

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
@@ -338,6 +338,7 @@ SelectJndiDataSourceDialog.undefined=<undefined>
 CreateDataSourceAction.label=Create Data Source
 CreateDataSourceAction.errorCreatingDataSource=Error creating data source
 CreateDataSourceAction.errorCreatingDataSourceForModel=Error creating data source for model {0}
+CreateDataSourceAction.errorDeployingDataSourceTryRestartMsg=The data source failed to deploy.  This may be due to a caching problem on the JBoss server.  Please stop and restart the server, then retry the deployment.
 CreateDataSourceAction.noConnectionInfoProvider.message=Could not resolve a IConnectionInfoProvider
 CreateDataSourceAction.noServer.title=No Teiid Server Available
 CreateDataSourceAction.noServer.message=No Teiid Server is available. Cannot create data source
@@ -515,6 +516,10 @@ GenerateRestWarAction.invalidJDKMessage=The compilation functionality of the war
 #########################################
 EnablePreviewPreferenceContributor.name = Enable Preview
 EnablePreviewPreferenceContributor.toolTip = Enables data preview using Teiid
+
+##### EnableTeiidPreviewCleanupPreferenceContributor
+EnablePreviewDeleteRASourcesPreferenceContributor.name = Enable Preview Cleanup of Resource Adapter Sources
+EnablePreviewDeleteRASourcesPreferenceContributor.toolTip = Enables the deleting of Resource Adapter data sources used in Preview VDBs from Teiid
 
 ##### EnableTeiidPreviewCleanupPreferenceContributor
 EnableTeiidPreviewCleanupPreferenceContributor.name = Enable Preview Teiid Cleanup

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/preferences/EnablePreviewDeleteRASourcesPreferenceContributor.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/preferences/EnablePreviewDeleteRASourcesPreferenceContributor.java
@@ -1,0 +1,156 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.teiid.designer.runtime.ui.preferences;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.osgi.service.prefs.BackingStoreException;
+import org.teiid.core.designer.util.I18nUtil;
+import org.teiid.designer.runtime.DqpPlugin;
+import org.teiid.designer.runtime.PreferenceConstants;
+import org.teiid.designer.runtime.ui.DqpUiConstants;
+import org.teiid.designer.ui.common.util.WidgetFactory;
+import org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor;
+
+
+/**
+ * EnablePreviewDeleteRASourcesPreferenceContributor
+ * This is 'false' by default.  We do not want Resource Adapter sources to be deleted by the preview manager,
+ * due to EAP 6.1 bug.  We can change the default or remove after EAP 6.1 bug is fixed.
+ * @since 8.2
+ */
+public class EnablePreviewDeleteRASourcesPreferenceContributor implements IGeneralPreferencePageContributor, DqpUiConstants {
+
+    private static final String PREFIX = I18nUtil.getPropertyPrefix(EnablePreviewDeleteRASourcesPreferenceContributor.class);
+
+    private Button chkEnabled;
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#createPreferenceEditor(org.eclipse.swt.widgets.Composite)
+     * @since 5.0
+     */
+    @Override
+	public void createPreferenceEditor( Composite theParent ) {
+        Composite pnl = new Composite(theParent, SWT.NONE);
+        pnl.setLayout(new GridLayout());
+        pnl.setLayoutData(new GridData());
+
+        this.chkEnabled = WidgetFactory.createCheckBox(pnl, getName());
+        this.chkEnabled.setLayoutData(new GridData());
+        this.chkEnabled.setToolTipText(getToolTip());
+
+        // initialize state
+        refresh();
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#getName()
+     * @since 5.0
+     */
+    @Override
+	public String getName() {
+        return UTIL.getStringOrKey(PREFIX + "name"); //$NON-NLS-1$
+    }
+
+    /**
+     * Obtains the <code>IEclipsePreferences</code> where this preference is being persisted.
+     * 
+     * @return the preferences
+     */
+    private IEclipsePreferences getPreferences() {
+        return DqpPlugin.getInstance().getPreferences();
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#getToolTip()
+     * @since 5.0
+     */
+    @Override
+	public String getToolTip() {
+        return UTIL.getStringOrKey(PREFIX + "toolTip"); //$NON-NLS-1$
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#performCancel()
+     * @since 5.0
+     */
+    @Override
+	public boolean performCancel() {
+        return true;
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#performDefaults()
+     * @since 5.0
+     */
+    @Override
+	public boolean performDefaults() {
+        this.chkEnabled.setSelection(PreferenceConstants.PREVIEW_DELETE_RA_SOURCES_ENABLED_DEFAULT);
+
+        // save
+        try {
+            getPreferences().flush();
+            return true;
+        } catch (BackingStoreException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#performOk()
+     * @since 5.0
+     */
+    @Override
+	public boolean performOk() {
+        IEclipsePreferences prefs = getPreferences();
+        prefs.putBoolean(PreferenceConstants.PREVIEW_DELETE_RA_SOURCES_ENABLED, this.chkEnabled.getSelection());
+
+        // save
+        try {
+            prefs.flush();
+            return true;
+        } catch (BackingStoreException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#refresh()
+     * @since 5.0
+     */
+    @Override
+	public void refresh() {
+        IEclipsePreferences prefs = getPreferences();
+        boolean enable = prefs.getBoolean(PreferenceConstants.PREVIEW_DELETE_RA_SOURCES_ENABLED,
+                                          PreferenceConstants.PREVIEW_DELETE_RA_SOURCES_ENABLED_DEFAULT);
+        this.chkEnabled.setSelection(enable);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#setPreferencePage(org.eclipse.jface.preference.PreferencePage)
+     */
+    public void setPreferencePage( PreferencePage preferencePage ) {
+    }
+
+    /**
+     * @see org.teiid.designer.ui.preferences.IGeneralPreferencePageContributor#setWorkbench(org.eclipse.ui.IWorkbench)
+     * @since 5.0
+     */
+    @Override
+	public void setWorkbench( IWorkbench theWorkbench ) {
+    }
+
+}

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/PreferenceConstants.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/PreferenceConstants.java
@@ -59,4 +59,14 @@ public interface PreferenceConstants {
      */
     boolean PREVIEW_TEIID_CLEANUP_ENABLED_DEFAULT = true;
 
+    /**
+     * The name of the preference indicating if Preview is allowed to delete RA sources from Teiid instances.
+     */
+    String PREVIEW_DELETE_RA_SOURCES_ENABLED = PLUGIN_ID + ".preferences.PreviewDeleteRASourcesEnabled"; //$NON-NLS-1$
+
+    /**
+     * The default value for the {@link #PREVIEW_DELETE_RA_SOURCES_ENABLED} preference. Default value is {@value} .
+     */
+    boolean PREVIEW_DELETE_RA_SOURCES_ENABLED_DEFAULT = false;
+
 }

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
@@ -65,6 +65,7 @@ public class Messages extends NLS {
     public static String dataSourcePanel_deleteSourceDialogTitle;
     public static String dataSourcePanel_deleteSourceDialogMsg;
     public static String dataSourcePanel_driverTooltipPrefix;
+    public static String dataSourcePanel_dataSourceDeployErrorTryRestartMsg;
     
     public static String dataSourceDriversPanelAddHyperlinkTxt;
     public static String dataSourceDriversPanelErrorNoSelection;

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
@@ -56,6 +56,7 @@ dataSourcePanel_copyErrorTitle=Error Copying DataSource
 dataSourcePanel_deleteSourceDialogTitle=Delete DataSource
 dataSourcePanel_deleteSourceDialogMsg=Do you really want to delete this DataSource?
 dataSourcePanel_driverTooltipPrefix=Driver for :
+dataSourcePanel_dataSourceDeployErrorTryRestartMsg=The data source failed to deploy.  This may be due to a caching problem on the JBoss server.  Please stop and restart the server, then retry the deployment.
 
 dataSourceDriversPanelAddHyperlinkTxt=Add Driver...
 dataSourceDriversPanelErrorNoSelection=Select a DataSource Driver

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePanel.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePanel.java
@@ -293,7 +293,12 @@ public final class DataSourcePanel extends Composite implements UiConstants {
             
             // If create failed, show Error Dialog
             if(!createStatus.isOK()) {
-                ErrorDialog.openError(Display.getCurrent().getActiveShell(),Messages.dataSourcePanel_createErrorTitle, createStatus.getMessage(), createStatus); 
+            	String message = createStatus.getMessage();
+            	if(message.startsWith("TEIID70006 JBAS014749")) {  //$NON-NLS-1$
+                    ErrorDialog.openError(Display.getCurrent().getActiveShell(),Messages.dataSourcePanel_createErrorTitle, Messages.dataSourcePanel_dataSourceDeployErrorTryRestartMsg, createStatus); 
+            	} else {
+            		ErrorDialog.openError(Display.getCurrent().getActiveShell(),Messages.dataSourcePanel_createErrorTitle, message, createStatus); 
+            	}
             }
             
             // Refresh the table and select the just-deployed template


### PR DESCRIPTION
- Detects exception caused by JBoss Server caching issue, instructs user to restart server and retry.
- Also, due to the server caching issue (for Preview RA datasources only), the DeleteDeployedPreviewVdbJob now does not remove the preview source.
