### PR TITLE
TEIIDDES-1289 ModeShape ConnectionProfile not set after model import

### DIFF
--- a/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/JdbcTranslatorHelper.java
+++ b/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/JdbcTranslatorHelper.java
@@ -84,6 +84,10 @@ public class JdbcTranslatorHelper {
 				return DB2;
 			}
 			
+			if( vendor.toUpperCase().startsWith(MODESHAPE.toUpperCase()) ) {
+				return MODESHAPE;
+			}
+
 			if( vendor.toUpperCase().startsWith(MYSQL.toUpperCase()) ) {
 				if( version != null && version.startsWith("5")) { //$NON-NLS-1$
 					return MYSQL5;

--- a/plugins/org.teiid.designer.jdbc.ui/src/org/teiid/designer/jdbc/ui/wizards/JdbcImportWizard.java
+++ b/plugins/org.teiid.designer.jdbc.ui/src/org/teiid/designer/jdbc/ui/wizards/JdbcImportWizard.java
@@ -739,13 +739,6 @@ public class JdbcImportWizard extends AbstractWizard
                 // Moved this call to AFTER the MODEL TYPE has been set.
                 ModelUtilities.initializeModelContainers(resrc, "Jdbc Import", this); //$NON-NLS-1$
 
-                // If connection profile is cached, which it should, go ahead and inject the data into the
-                // model resource.
-                if (this.connectionProfile != null) {
-                    IConnectionInfoProvider provider = new JDBCConnectionInfoProvider();
-                    provider.setConnectionInfo(resrc, this.connectionProfile);
-                }
-
                 if( this.isVdbSourceModel && srcPg.isTeiidConnection() ) {
                 	// Inject VDB source model properties: locked = TRUE, vdb-name = "xxxx" , vdb-version = "y"
                 	ModelExtensionRegistry registry = ExtensionPlugin.getInstance().getRegistry();
@@ -771,11 +764,6 @@ public class JdbcImportWizard extends AbstractWizard
                                                                                       getDatabase(),
                                                                                       ppProcessorPack.getJdbcSource().getImportSettings(),
                                                                                       monitor);
-                // Reset the connection profile, since it may have changed
-                if (this.connectionProfile != null) {
-                    IConnectionInfoProvider provider = new JDBCConnectionInfoProvider();
-                    provider.setConnectionInfo(ppProcessorPack.getModelResource(), this.connectionProfile);
-                }
             }
             sWatch.stop();
 
@@ -815,6 +803,12 @@ public class JdbcImportWizard extends AbstractWizard
 
                 sWatch.stop();
                 sWatch.start(true);
+
+                // Inject the connectionProfile into the ModelResource
+                if (this.connectionProfile != null) {
+                    IConnectionInfoProvider provider = new JDBCConnectionInfoProvider();
+                    provider.setConnectionInfo(ppProcessorPack.getModelResource(), this.connectionProfile);
+                }
 
                 // Check if Virtual, then re-set ModelType
                 if( isVirtual ) {


### PR DESCRIPTION
- Moved the point at which the ConnectionProfile is injected into the ModelResource in JdbcImportWizard. retested ok.
- Added Modeshape translator to JdbcTranslatorHelper, since it was not being set correctly.
