### PR TITLE
TEIIDDES-1826 Corrects problem when single file is chosen in FlatFile Connection Profile

### DIFF
--- a/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/profiles/flatfile/FlatFileConnectionInfoProvider.java
+++ b/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/profiles/flatfile/FlatFileConnectionInfoProvider.java
@@ -1,5 +1,6 @@
 package org.teiid.designer.datatools.profiles.flatfile;
 
+import java.io.File;
 import java.util.Properties;
 import org.eclipse.datatools.connectivity.IConnectionProfile;
 import org.teiid.designer.core.ModelerCore;
@@ -47,7 +48,14 @@ public class FlatFileConnectionInfoProvider  extends ConnectionInfoHelper implem
         	connectionProps.put(IFlatFileProfileConstants.TEIID_PARENT_DIRECTORY_KEY, baseProps.get(IFlatFileProfileConstants.HOME_URL));
         } else if( baseProps.getProperty(IFlatFileProfileConstants.HOME_KEY) != null ) {
         	connectionProps.put(IFlatFileProfileConstants.TEIID_PARENT_DIRECTORY_KEY, baseProps.get(IFlatFileProfileConstants.HOME_KEY));
-        } 
+        } else if( baseProps.getProperty(IFlatFileProfileConstants.URI_KEY) != null ) {
+        	String uri = baseProps.getProperty(IFlatFileProfileConstants.URI_KEY);
+        	// Get Parent Folder path using file path
+        	String parentPath = getFileParentDir(uri);
+        	if(parentPath!=null) {
+            	connectionProps.put(IFlatFileProfileConstants.TEIID_PARENT_DIRECTORY_KEY, parentPath);
+        	}
+        }
 
         connectionProps.setProperty(FILE_CLASSNAME, FILE_CONNECTION_FACTORY);
         return connectionProps;
@@ -65,6 +73,16 @@ public class FlatFileConnectionInfoProvider  extends ConnectionInfoHelper implem
 		if (null != result) {
 			connectionProps.setProperty(CONNECTION_NAMESPACE
 					+ IFlatFileProfileConstants.HOME_URL, result);
+		} else {
+			result = props.getProperty(IFlatFileProfileConstants.URI_KEY);
+			if(null != result) {
+	        	// Get Parent Folder path using file path
+	        	String parentPath = getFileParentDir(result);
+	        	if(parentPath!=null) {
+					connectionProps.setProperty(CONNECTION_NAMESPACE
+							+ IFlatFileProfileConstants.HOME_URL, parentPath);
+	        	}
+			}
 		}
 
 		result = props.getProperty(IFlatFileProfileConstants.DELIMTYPE_KEY);
@@ -101,6 +119,20 @@ public class FlatFileConnectionInfoProvider  extends ConnectionInfoHelper implem
 
 	}
 
+	private String getFileParentDir(String filePath) {
+		String dirPath = null;
+		if(filePath != null) {
+			File aFile = new File(filePath);
+			if(aFile.exists() && aFile.isFile()) {
+				File dirFile = aFile.getParentFile();
+				if(dirFile!=null && dirFile.exists() && dirFile.isDirectory()) {
+					dirPath = dirFile.getAbsolutePath();
+				}
+			}
+		}
+		return dirPath;
+	}
+	
 	@Override
 	public Properties getCommonProfileProperties(IConnectionProfile profile) {
 		return super.getCommonProfileProperties(profile);

--- a/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/profiles/flatfile/IFlatFileProfileConstants.java
+++ b/plugins/org.teiid.designer.datatools/src/org/teiid/designer/datatools/profiles/flatfile/IFlatFileProfileConstants.java
@@ -47,6 +47,7 @@ public interface IFlatFileProfileConstants {
 	String SECOND_LINE_DATATYPE = "FlatFileSecondLineDataType"; //$NON-NLS-1$
 	
 	String HOME_KEY = "HOME"; //$NON-NLS-1$
+	String URI_KEY = "URI"; //$NON-NLS-1$
 	String DELIMTYPE_KEY = "DELIMTYPE"; //$NON-NLS-1$
 	String CHARSET_KEY = "CHARSET"; //$NON-NLS-1$
 	String INCLTYPELINE_KEY = "INCLTYPELINE"; //$NON-NLS-1$

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/i18n.properties
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/i18n.properties
@@ -838,6 +838,9 @@ TeiidMetadataImportSourcePage.malformedUrlErrorMessage=Error building URL from [
 TeiidMetadataImportSourcePage.parsingErrorTitle=XML File Parsing Error
 TeiidMetadataImportSourcePage.noConnectionProfileSelected = Please select a Data File Source
 TeiidMetadataImportSourcePage.invalidXmlFileConnProfileMesage = The Data File Source does not reference a valid XML file
+TeiidMetadataImportSourcePage.unknownFolderText = Unknown
+TeiidMetadataImportSourcePage.unknownFolderErrorMsg = The Folder Location could not be found on the file system.  Please check the Connection Profile.
+TeiidMetadataImportSourcePage.unknownFolderTooltip = The folder could not be found
 
 TeiidMetadataImportFormatPage.title=Flat File Column Format Definition
 TeiidMetadataImportFormatPage.messageTitle=Select Column Format For Data File {0}


### PR DESCRIPTION
- The user is allowed to choose a single file in the Flat File Connection Profile, but we were not handling that case.  Now setting the 'ParentDirectory' property successfully for this case.
- The user is also allowed to enter a remote file URI in the Flat File connection profile.  More work is required in Designer for this scenario (need to utilize WebService RA instead of File RA, same as we do with XML).  
- Added checks for the URI case to let user know the local dir was not found
