### PR TITLE
Updates the feature dependencies

### DIFF
--- a/features/org.teiid.datatools.connectivity.feature/feature.xml
+++ b/features/org.teiid.datatools.connectivity.feature/feature.xml
@@ -30,6 +30,48 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.eclipse.ui" version="3.103.0" match="compatible"/>
+      <import plugin="org.eclipse.core.runtime" version="3.8.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity" version="1.2.5" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity.sqm.core" version="1.2.5" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.parsers.sql" version="1.0.2" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity.sqm.server.ui" version="1.1.100" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity.model" version="8.1.0" match="compatible"/>
+      <import plugin="org.eclipse.equinox.security" version="1.1.100" match="compatible"/>
+      <import plugin="org.teiid.designer.spi" version="8.1.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.modelbase.dbdefinition"/>
+      <import plugin="org.eclipse.datatools.modelbase.sql"/>
+      <import plugin="org.eclipse.emf.common"/>
+      <import plugin="org.eclipse.emf.ecore"/>
+      <import plugin="org.eclipse.emf.ecore.xmi"/>
+      <import plugin="org.eclipse.datatools.connectivity.ui" version="1.2.3" match="compatible"/>
+      <import plugin="org.eclipse.datatools.help" version="1.5.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.plan" version="1.0.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.editor.core.ui" version="1.0.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.sqleditor" version="1.0.2" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.data.core" version="1.2.1" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.sql" version="1.0.1" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity" version="8.1.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.result.ui" version="1.1.2" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity.sqm.core.ui" version="1.2.2" match="compatible"/>
+      <import plugin="org.eclipse.ui.navigator" version="3.5.200" match="compatible"/>
+      <import plugin="org.eclipse.emf.ecore" version="2.8.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.modelbase.sql" version="1.0.5" match="compatible"/>
+      <import plugin="org.eclipse.debug.core" version="3.7.100" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.editor.core" version="1.0.2" match="compatible"/>
+      <import plugin="org.eclipse.datatools.sqltools.routineeditor" version="1.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.ui" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.ui.common" version="8.2.0" match="compatible"/>
+      <import plugin="org.jboss.tools.locus.sf.saxon" version="9.2.1" match="compatible"/>
+      <import plugin="org.apache.xerces"/>
+      <import plugin="org.eclipse.core.runtime.compatibility" version="3.2.200" match="compatible"/>
+      <import plugin="org.eclipse.core.resources" version="3.8.0" match="compatible"/>
+      <import plugin="org.eclipse.wst.server.core" version="1.4.0" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity.ui" version="8.2.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.datatools.connectivity.oda.flatfile.ui" version="3.1.7" match="compatible"/>
+   </requires>
+
    <plugin
          id="org.teiid.datatools.connectivity"
          download-size="0"

--- a/features/org.teiid.designer.feature/feature.xml
+++ b/features/org.teiid.designer.feature/feature.xml
@@ -38,6 +38,7 @@
          ws="gtk"/>
 
    <requires>
+      <import feature="org.jboss.ide.eclipse.as.feature" version="2.4.100" match="compatible"/>
       <import plugin="org.eclipse.ui.cheatsheets" version="3.4.200" match="compatible"/>
       <import plugin="org.eclipse.ui.ide" version="3.8.0" match="compatible"/>
       <import plugin="org.eclipse.ui.views" version="3.6.100" match="compatible"/>
@@ -82,11 +83,18 @@
       <import plugin="org.eclipse.ui.navigator" version="3.5.200" match="compatible"/>
       <import plugin="org.eclipse.ui.navigator.resources" version="3.4.400" match="compatible"/>
       <import plugin="org.teiid.designer.spi" version="8.1.0" match="compatible"/>
-      <import plugin="org.apache.xerces"/>
+      <import plugin="org.eclipse.datatools.sqltools.editor.core" version="1.0.2" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.datatools.sqltools.sqleditor" version="1.0.2" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.datatools.sqltools.sqlscrapbook" version="1.0.2" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.datatools" version="8.1.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ltk.core.refactoring" version="3.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ltk.ui.refactoring" version="3.7.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.vdb" version="8.1.0" match="greaterOrEqual"/>
       <import plugin="org.jboss.tools.locus.sf.saxon" version="9.2.1" match="compatible"/>
       <import plugin="org.eclipse.emf.ecore" version="2.8.0" match="compatible"/>
       <import plugin="org.eclipse.emf.edit" version="2.8.0" match="compatible"/>
       <import plugin="org.eclipse.emf.common" version="2.8.0" match="compatible"/>
+      <import plugin="org.eclipse.ui" version="3.103.0" match="greaterOrEqual"/>
       <import plugin="org.apache.poi" version="3.9.0" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity" version="1.2.5" match="compatible"/>
       <import plugin="org.teiid.designer.compare.ui" version="8.1.0" match="compatible"/>
@@ -98,7 +106,7 @@
       <import plugin="org.eclipse.jface" version="3.8.0" match="compatible"/>
       <import plugin="org.eclipse.draw2d" version="3.8.0" match="compatible"/>
       <import plugin="org.eclipse.gef" version="3.8.0" match="compatible"/>
-      <import plugin="org.eclipse.swt" version="3.100.0" match="compatible"/>
+      <import plugin="org.eclipse.core.resources" version="3.8.1" match="greaterOrEqual"/>
       <import plugin="org.teiid.designer.diagram.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.query.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.transformation.ui" version="8.1.0" match="compatible"/>
@@ -110,6 +118,9 @@
       <import plugin="org.teiid.designer.relational.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.core.expressions" version="3.4.400" match="compatible"/>
       <import plugin="org.teiid.datatools.connectivity.ui" version="8.1.0" match="compatible"/>
+      <import plugin="org.eclipse.search" version="3.8.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.udf" version="8.2.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.xerces"/>
       <import plugin="org.teiid.designer.mapping.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.emf" version="2.6.0" match="compatible"/>
       <import plugin="org.apache.xerces" version="2.9.0" match="compatible"/>
@@ -118,6 +129,7 @@
       <import plugin="org.eclipse.wst.wsdl.validation" version="1.1.600" match="compatible"/>
       <import plugin="org.teiid.designer.xml.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.ui.workbench" version="3.103.0" match="compatible"/>
+      <import plugin="org.teiid.designer.extension" version="8.0.0" match="greaterOrEqual"/>
       <import plugin="org.teiid.designer.metamodels.builder" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.text" version="3.5.200" match="compatible"/>
       <import plugin="org.teiid.designer.modeshape" version="8.1.0" match="compatible"/>
@@ -125,27 +137,51 @@
       <import plugin="org.apache.commons.codec" version="1.3.0" match="compatible"/>
       <import plugin="org.apache.commons.discovery" version="0.2.0" match="compatible"/>
       <import plugin="javax.xml.rpc" version="1.1.0" match="compatible"/>
+      <import plugin="javax.servlet" version="3.0.0" match="greaterOrEqual"/>
       <import plugin="javax.wsdl" version="1.6.2" match="compatible"/>
+      <import plugin="javax.xml.soap" version="1.3.0" match="compatible"/>
+      <import plugin="org.apache.commons.httpclient" version="3.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.modelgenerator.salesforce" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.datatools.help" version="1.5.0" match="compatible"/>
+      <import plugin="org.teiid.designer.relational" version="8.1.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.osgi" version="3.8.0" match="compatible"/>
       <import plugin="org.jboss.tools.locus.jcip.annotations" version="1.0.0" match="compatible"/>
       <import plugin="org.teiid.designer.roles" version="8.1.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.function" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.metamodels.relational" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.spi" version="8.2.0" match="greaterOrEqual"/>
       <import plugin="org.teiid.designer.vdb" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.roles.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.core.runtime.compatibility" version="3.2.200" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity.oda.flatfile" version="3.1.2" match="compatible"/>
+      <import plugin="org.codehaus.jackson.core" version="1.6.0" match="compatible"/>
+      <import plugin="org.codehaus.jackson.mapper" version="1.6.0" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity.ui.dse" version="1.1.4" match="compatible"/>
       <import plugin="org.eclipse.datatools.enablement.oda.xml" version="1.2.3" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity.oda" version="3.3.3" match="compatible"/>
       <import plugin="org.teiid.designer.modelgenerator.wsdl" version="8.1.0" match="compatible"/>
+      <import plugin="org.teiid.designer.jdbc" version="8.1.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.ddl.spi" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.extension" version="8.2.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.relational" version="8.2.0" match="greaterOrEqual"/>
       <import plugin="org.teiid.designer.ddl.importer" version="8.1.0" match="compatible"/>
+      <import plugin="org.teiid.designer.relational.ui" version="8.2.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.metamodels.diagram" version="8.1.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.metamodels.transformation" version="8.1.0" match="greaterOrEqual"/>
       <import plugin="org.teiid.designer.schema.tools" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.wst.wsdl" version="1.2.300" match="compatible"/>
       <import plugin="org.teiid.designer.modelgenerator.xml" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.xsd.ui" version="8.1.0" match="compatible"/>
+      <import plugin="org.eclipse.swt" version="3.100.0" match="compatible"/>
       <import plugin="org.eclipse.wst.xsd.ui" version="1.2.500" match="compatible"/>
       <import plugin="org.eclipse.wst.server.core" version="1.4.0" match="compatible"/>
+      <import plugin="org.teiid.core.designer" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.compare" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.core" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.core" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.relational" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.modeshape" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.designer.spi" version="8.2.0" match="compatible"/>
    </requires>
 
    <plugin
@@ -590,27 +626,6 @@
 
    <plugin
          id="org.teiid.designer.spi"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.poi"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.jboss.tools.locus.jcip.annotations"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.jboss.tools.locus.sf.saxon"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.teiid.designer.runtime.feature/feature.xml
+++ b/features/org.teiid.designer.runtime.feature/feature.xml
@@ -29,6 +29,7 @@ Including: Connection management, VDB creation and management and Data Preview/V
          version="0.0.0"/>
 
    <requires>
+      <import feature="org.jboss.ide.eclipse.as.feature" version="2.4.100" match="compatible"/>
       <import plugin="org.eclipse.core.runtime" version="3.8.0" match="compatible"/>
       <import plugin="org.eclipse.ui" version="3.103.0" match="compatible"/>
       <import plugin="org.jdom" version="1.1.1" match="compatible"/>
@@ -43,6 +44,7 @@ Including: Connection management, VDB creation and management and Data Preview/V
       <import plugin="org.teiid.designer.legacy" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.vdb" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity" version="1.2.5" match="compatible"/>
+      <import plugin="org.jboss.tools.locus.jcip.annotations" version="1.0.0" match="compatible"/>
       <import plugin="org.teiid.designer.datatools" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.metamodels.relational" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.designer.metamodels.webservice" version="8.1.0" match="compatible"/>
@@ -55,6 +57,7 @@ Including: Connection management, VDB creation and management and Data Preview/V
       <import plugin="org.jboss.ide.eclipse.as.management.core" version="2.4.0" match="compatible"/>
       <import plugin="org.teiid.designer.relational" version="8.1.0" match="compatible"/>
       <import plugin="org.teiid.datatools.connectivity" version="8.1.0" match="compatible"/>
+      <import plugin="org.teiid.designer.spi" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.ui.views" version="3.6.100" match="compatible"/>
       <import plugin="org.eclipse.jface.text" version="3.8.0" match="compatible"/>
       <import plugin="org.eclipse.ui.workbench.texteditor" version="3.8.0" match="compatible"/>
@@ -86,46 +89,46 @@ Including: Connection management, VDB creation and management and Data Preview/V
       <import plugin="org.eclipse.datatools.sqltools.sqlscrapbook" version="1.0.2" match="compatible"/>
       <import plugin="org.eclipse.wst.server.ui" version="1.4.0" match="compatible"/>
       <import plugin="org.eclipse.ui.navigator" version="3.5.200" match="compatible"/>
+      <import plugin="org.jboss.ide.eclipse.as.ui" version="2.4.0" match="compatible"/>
       <import plugin="org.eclipse.ui.workbench" version="3.103.0" match="compatible"/>
       <import plugin="org.eclipse.datatools.connectivity.ui.dse" version="1.1.4" match="compatible"/>
       <import plugin="org.eclipse.ui.cheatsheets" version="3.4.200" match="compatible"/>
       <import plugin="org.teiid.designer.dqp.ui" version="8.1.0" match="compatible"/>
       <import plugin="org.eclipse.emf.ecore" version="2.8.0" match="compatible"/>
-      <import feature="org.eclipse.datatools.common.doc.user" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.connectivity.doc.user" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.connectivity.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.connectivity.oda.designer.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.connectivity.oda.feature" version="1.7.1" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.doc.user" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.apache.derby.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.hsqldb.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.ibm.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.ingres.feature" version="1.9.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.jdbc.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.jdt.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.msft.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.mysql.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.oda.designer.feature" version="1.7.1" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.oda.feature" version="1.7.1" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.oracle.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.postgresql.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.sap.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.sqlite.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.enablement.sybase.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.modelbase.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.data.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.ddl.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.ddlgen.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.parsers.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.results.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqldevtools.sqlbuilder.feature" version="1.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.datatools.sqltools.doc.user" version="1.7.0" match="greaterOrEqual"/>
-      <import plugin="org.jboss.tools.locus.jcip.annotations" version="1.0.0" match="compatible"/>
-      <import plugin="org.teiid.designer.spi" version="8.1.0" match="compatible"/>
-      <import plugin="org.jboss.ide.eclipse.as.ui" version="2.4.0" match="compatible"/>
+      <import plugin="org.eclipse.gef" version="3.8.0" match="compatible"/>
+      <import plugin="org.eclipse.draw2d" version="3.8.0" match="compatible"/>
+      <import plugin="org.teiid.designer.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.diagram" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.core" version="8.0.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.common" version="2.8.0" match="compatible"/>
+      <import plugin="org.teiid.designer.ui.common" version="8.0.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.ecore.xmi" version="2.8.0" match="compatible"/>
+      <import plugin="org.teiid.designer.diagram.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.query.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.transformation" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.tools.textimport.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.relational" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.relational.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.core.designer" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.core" version="8.0.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.mapping" version="2.7.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.transformation" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.function" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.legacy" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.metamodels.relational" version="8.0.0" match="compatible"/>
+      <import plugin="org.eclipse.core.expressions" version="3.4.400" match="compatible"/>
+      <import plugin="org.teiid.designer.datatools" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.datatools.ui" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.spi" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.designer.dqp" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.ddl.importer" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.compare" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.compare.ui" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.vdb" version="8.1.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui.forms" version="3.5.200" match="greaterOrEqual"/>
+      <import plugin="org.teiid.designer.ddl.importer.ui" version="8.2.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.xerces"/>
    </requires>
 
    <plugin

--- a/features/org.teiid.designer.teiid.client.feature/feature.xml
+++ b/features/org.teiid.designer.teiid.client.feature/feature.xml
@@ -21,6 +21,24 @@
          id="org.teiid.datatools.connectivity.feature"
          version="0.0.0"/>
 
+   <requires>
+      <import feature="org.jboss.ide.eclipse.as.feature" version="2.4.100" match="compatible"/>
+      <import plugin="org.jdom" version="1.1.1" match="compatible"/>
+      <import plugin="org.jboss.tools.locus.sf.saxon" version="9.2.1" match="compatible"/>
+      <import plugin="org.hamcrest.core" version="1.1.0" match="compatible"/>
+      <import plugin="org.teiid.designer.spi" version="8.0.0" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity" version="8.2.0" match="compatible"/>
+      <import plugin="org.teiid.datatools.connectivity.ui" version="8.2.0" match="compatible"/>
+      <import plugin="org.eclipse.core.runtime" version="3.8.0" match="compatible"/>
+      <import plugin="org.eclipse.core.resources" version="3.8.0" match="compatible"/>
+      <import plugin="org.eclipse.wst.server.core" version="1.4.0" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity" version="1.2.5" match="compatible"/>
+      <import plugin="org.eclipse.datatools.connectivity.ui" version="1.2.4" match="compatible"/>
+      <import plugin="org.jboss.ide.eclipse.as.core" version="2.4.0" match="compatible"/>
+      <import plugin="org.jboss.ide.eclipse.as.management.core" version="2.4.0" match="compatible"/>
+      <import plugin="org.eclipse.osgi"/>
+   </requires>
+
    <plugin
          id="org.teiid.8.4.x"
          download-size="0"


### PR DESCRIPTION
- Re-computes the plugin requirements of each feature
- Ensure that the org.jboss.ide.eclipse.as.feature is a dependency of the
  designer, runtime and client features. Since the jboss as71 plugin seems
  to be required to connect successfully to jboss 7.1 servers its never
  actually imported explicitly by any plugin hence causes connection
  failures with eclipse installations.
