### PR TITLE
TEIIDDES-305: Adds in statistics for performance optimisation

### DIFF
--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/RelationalModelBuilder.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/RelationalModelBuilder.java
@@ -39,8 +39,6 @@ import org.teiid.designer.ui.viewsupport.ModelUtilities;
  * The Model Builder for creating the physical model for LDAP services.
  */
 public class RelationalModelBuilder {
-//    private final LdapImportWizardManager importManager;
-
     private RelationalFactory factory;
 
     private DatatypeManager datatypeManager;
@@ -85,14 +83,15 @@ public class RelationalModelBuilder {
             entryTable.getColumns().add(attrColumn);
             attrColumn.setName(attribute.getLabel());
             attrColumn.setNameInSource(attribute.getId());
-            attrColumn.setLength(32768);
+            attrColumn.setNullValueCount(attribute.getNullValueCount());
+            attrColumn.setDistinctValueCount(attribute.getDistinctValueCount());
+            attrColumn.setLength(attribute.getMaximumValueLength());
+
+            attrColumn.setType(datatypeManager.getBuiltInDatatype(DatatypeConstants.BuiltInNames.STRING));
             attrColumn.setNullable(NullableType.NULLABLE_UNKNOWN_LITERAL);
             attrColumn.setCaseSensitive(true);
             attrColumn.setRadix(0);
             attrColumn.setSigned(false);
-            attrColumn.setDistinctValueCount(0);
-            attrColumn.setNullValueCount(0);
-            attrColumn.setType(datatypeManager.getBuiltInDatatype(DatatypeConstants.BuiltInNames.STRING));
         }
     }
 

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/i18n.properties
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/i18n.properties
@@ -100,6 +100,9 @@ LdapColumnsPage_description=The tree displays the selected entries and the attri
 LdapColumnsPage_columnAttributesTitle=Source Model Column Attributes
 LdapColumnsPage_detailColumnNameLabel=Column Name
 LdapColumnsPage_detailColumnSourceNameLabel=Column Source Name
+LdapColumnsPage_detailColumnDVCountLabel=Column Distinct Value Count
+LdapColumnsPage_detailColumnNVCountLabel=Column Null Value Count
+LdapColumnsPage_detailMaxValueLabel=Column Length
 LdapColumnsPage_sourceColumnsIncomplete=Not all selected source model tables contain columns
 
 #=================================================================================================================================

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/ILdapAttributeNode.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/ILdapAttributeNode.java
@@ -13,6 +13,11 @@ package org.teiid.designer.modelgenerator.ldap.ui.wizards;
 public interface ILdapAttributeNode {
 
     /**
+     * Value used for the default length
+     */
+    int DEFAULT_VALUE_LENGTH = 32768;
+
+    /**
      * @return the id
      */
     String getId();
@@ -31,4 +36,31 @@ public interface ILdapAttributeNode {
      * @param label
      */
     void setLabel(String label);
+
+    /**
+     * @return distinct value count
+     */
+    int getDistinctValueCount();
+
+    /**
+     * Increment the null value count
+     */
+    void incrementNullValueCount();
+
+    /**
+     * @return null value count
+     */
+    int getNullValueCount();
+
+    /**
+     * Add a value of this attribute. Used for calculation of a distinct value count
+     *
+     * @param value
+     */
+    void addValue(Object value);
+
+    /**
+     * @return the length of the longest value
+     */
+    int getMaximumValueLength();
 }

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/impl/LdapAttributeNode.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/impl/LdapAttributeNode.java
@@ -7,6 +7,8 @@
 */
 package org.teiid.designer.modelgenerator.ldap.ui.wizards.impl;
 
+import java.util.HashSet;
+import java.util.Set;
 import javax.naming.directory.Attribute;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.ILdapAttributeNode;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.ILdapEntryNode;
@@ -21,6 +23,12 @@ public class LdapAttributeNode implements ILdapAttributeNode {
     private final String id;
 
     private final ILdapEntryNode associatedEntry;
+
+    private int nullValueCount;
+
+    private Set<Object> values = new HashSet<Object>();
+
+    private int maxValueLength = 0;
 
     /**
      * @param associatedEntry
@@ -56,6 +64,42 @@ public class LdapAttributeNode implements ILdapAttributeNode {
     @Override
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    @Override
+    public void incrementNullValueCount() {
+        ++nullValueCount;
+    }
+
+    @Override
+    public int getNullValueCount() {
+        if (nullValueCount == 0)
+            return -1; // Supposed to return this for no null values
+
+        return this.nullValueCount;
+    }
+
+    @Override
+    public void addValue(Object value) {
+        if (value == null)
+            return;
+
+        boolean added = values.add(value);
+        if(added)
+            maxValueLength = Math.max(maxValueLength, value.toString().length());
+    }
+
+    @Override
+    public int getDistinctValueCount() {
+        return values.size();
+    }
+
+    @Override
+    public int getMaximumValueLength() {
+        if (maxValueLength == 0)
+            return DEFAULT_VALUE_LENGTH;
+
+        return maxValueLength ;
     }
 
     @Override

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/columns/LdapColumnsPage.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/columns/LdapColumnsPage.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
@@ -58,6 +59,8 @@ public class LdapColumnsPage extends WizardPage
     implements IChangeListener, ModelGeneratorLdapUiConstants, ModelGeneratorLdapUiConstants.Images,
     ModelGeneratorLdapUiConstants.HelpContexts {
 
+    private static final String NULL_STRING = ""; //$NON-NLS-1$
+
     private static final int[] SPLITTER_WEIGHTS = new int[] {30, 70};
 
     private final LdapImportWizardManager importManager;
@@ -72,6 +75,12 @@ public class LdapColumnsPage extends WizardPage
     private Text columnNameText;
 
     private Text columnSourceNameText;
+
+    private Text columnDVCountText;
+
+    private Text columnNVCountText;
+
+    private Text columnMaxValueText;
 
     private boolean synchronising;
 
@@ -109,10 +118,16 @@ public class LdapColumnsPage extends WizardPage
             columnNameText.setText(attributeNode.getLabel());
             columnNameText.setEditable(true);
             columnSourceNameText.setText(attributeNode.getId());
+            columnDVCountText.setText(Integer.toString(attributeNode.getDistinctValueCount()));
+            columnNVCountText.setText(Integer.toString(attributeNode.getNullValueCount()));
+            columnMaxValueText.setText(Integer.toString(attributeNode.getMaximumValueLength()));
         } else {
-            columnNameText.setText(""); //$NON-NLS-1$
+            columnNameText.setText(NULL_STRING);
             columnNameText.setEditable(false);
-            columnSourceNameText.setText(""); //$NON-NLS-1$
+            columnSourceNameText.setText(NULL_STRING);
+            columnDVCountText.setText(NULL_STRING);
+            columnNVCountText.setText(NULL_STRING);
+            columnMaxValueText.setText(NULL_STRING);
         }
     }
 
@@ -158,6 +173,16 @@ public class LdapColumnsPage extends WizardPage
 
             treeItemChecked(treeItem, false);
         }
+    }
+
+    private void setNonEditable(Text control) {
+        if (control == null)
+            return;
+
+        Display display = control.getDisplay();
+        control.setForeground(display.getSystemColor(SWT.COLOR_DARK_BLUE));
+        control.setBackground(display.getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW));
+        control.setEditable(false);
     }
 
     @Override
@@ -270,8 +295,8 @@ public class LdapColumnsPage extends WizardPage
 
         detailsView.setContent(detailsGroup);
 
-        Label tableNameLabel = new Label(detailsGroup, SWT.NONE);
-        tableNameLabel.setText(getString("detailColumnNameLabel")); //$NON-NLS-1$
+        Label columnNameLabel = new Label(detailsGroup, SWT.NONE);
+        columnNameLabel.setText(getString("detailColumnNameLabel")); //$NON-NLS-1$
 
         columnNameText = new Text(detailsGroup, SWT.BORDER | SWT.SINGLE);
         GridDataFactory.fillDefaults().grab(true, false).applyTo(columnNameText);
@@ -297,14 +322,33 @@ public class LdapColumnsPage extends WizardPage
             }
         });
 
-        Label tableSourceNameLabel = new Label(detailsGroup, SWT.NONE);
-        tableSourceNameLabel.setText(getString("detailColumnSourceNameLabel")); //$NON-NLS-1$
+        Label columnSourceNameLabel = new Label(detailsGroup, SWT.NONE);
+        columnSourceNameLabel.setText(getString("detailColumnSourceNameLabel")); //$NON-NLS-1$
 
         columnSourceNameText = new Text(detailsGroup, SWT.BORDER | SWT.SINGLE);
         GridDataFactory.fillDefaults().grab(true, false).applyTo(columnSourceNameText);
-        columnSourceNameText.setForeground(columnSourceNameText.getDisplay().getSystemColor(SWT.COLOR_DARK_BLUE));
-        columnSourceNameText.setBackground(columnSourceNameText.getDisplay().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW));
-        columnSourceNameText.setEditable(false);
+        setNonEditable(columnSourceNameText);
+
+        Label columnDVCountLabel = new Label(detailsGroup, SWT.NONE);
+        columnDVCountLabel.setText(getString("detailColumnDVCountLabel")); //$NON-NLS-1$
+
+        columnDVCountText = new Text(detailsGroup, SWT.BORDER | SWT.SINGLE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(columnDVCountText);
+        setNonEditable(columnDVCountText);
+
+        Label columnNVCountLabel = new Label(detailsGroup, SWT.NONE);
+        columnNVCountLabel.setText(getString("detailColumnNVCountLabel")); //$NON-NLS-1$
+
+        columnNVCountText = new Text(detailsGroup, SWT.BORDER | SWT.SINGLE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(columnNVCountText);
+        setNonEditable(columnNVCountText);
+
+        Label maxValueLabel = new Label(detailsGroup, SWT.NONE);
+        maxValueLabel.setText(getString("detailMaxValueLabel")); //$NON-NLS-1$
+
+        columnMaxValueText = new Text(detailsGroup, SWT.BORDER | SWT.SINGLE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(columnMaxValueText);
+        setNonEditable(columnMaxValueText);
 
         this.splitter.setWeights(SPLITTER_WEIGHTS);
 


### PR DESCRIPTION
- To optimise the query, the distinct value and null value counts are
  required. These properties can be set using the searches already
  conducted when displaying the child attributes in the column page tree
- Adds fields to LdapAttributeNode for the null value count, distinct value
  count and maximum length of the attribute's values.
