### PR TITLE
TEIIDDES-1910: Fix validation issues with WSDL property pages

### DIFF
--- a/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/WSSoapPropertyPage.java
+++ b/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/WSSoapPropertyPage.java
@@ -50,6 +50,14 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
 
     private Text endPointText;
 
+    private Label endPointNameLabel;
+
+    private Text endPointNameText;
+
+    private Label bindingTypeLabel;
+
+    private Text bindingTypeText;
+
     /**
      * Create a new default instance
      */
@@ -135,6 +143,38 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
         gd.horizontalSpan = 1;
         endPointText.setLayoutData(gd);
 
+        endPointNameLabel = new Label(scrolled, SWT.NONE);
+        endPointNameLabel.setText(UTIL.getString("WSSoapPropertyPage.endPointNameName")); //$NON-NLS-1$
+        endPointNameLabel.setToolTipText(UTIL.getString("WSSoapPropertyPage.endPointName.ToolTip")); //$NON-NLS-1$
+        gd = new GridData();
+        gd.verticalAlignment = GridData.BEGINNING;
+        endPointNameLabel.setLayoutData(gd);
+
+        endPointNameText = new Text(scrolled, SWT.SINGLE | SWT.BORDER);
+        endPointNameText.setToolTipText(UTIL.getString("WSSoapPropertyPage.endPointName.ToolTip")); //$NON-NLS-1$
+        gd = new GridData();
+        gd.horizontalAlignment = GridData.FILL;
+        gd.verticalAlignment = GridData.BEGINNING;
+        gd.grabExcessHorizontalSpace = true;
+        gd.horizontalSpan = 1;
+        endPointNameText.setLayoutData(gd);
+
+        bindingTypeLabel = new Label(scrolled, SWT.NONE);
+        bindingTypeLabel.setText(UTIL.getString("WSSoapPropertyPage.endPointBindingLabel")); //$NON-NLS-1$
+        bindingTypeLabel.setToolTipText(UTIL.getString("WSSoapPropertyPage.endPointBinding.ToolTip")); //$NON-NLS-1$
+        gd = new GridData();
+        gd.verticalAlignment = GridData.BEGINNING;
+        bindingTypeLabel.setLayoutData(gd);
+
+        bindingTypeText = new Text(scrolled, SWT.SINGLE | SWT.BORDER);
+        bindingTypeText.setToolTipText(UTIL.getString("WSSoapPropertyPage.endPointBinding.ToolTip")); //$NON-NLS-1$
+        gd = new GridData();
+        gd.horizontalAlignment = GridData.FILL;
+        gd.verticalAlignment = GridData.BEGINNING;
+        gd.grabExcessHorizontalSpace = true;
+        gd.horizontalSpan = 1;
+        bindingTypeText.setLayoutData(gd);
+
         initControls();
         addlisteners();
     }
@@ -151,6 +191,8 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
 
         urlText.addListener(SWT.Modify, listener);
         endPointText.addListener(SWT.Modify, listener);
+        endPointNameText.addListener(SWT.Modify, listener);
+        bindingTypeText.addListener(SWT.Modify, listener);
 
         credentialsComposite.addSecurityOptionListener(SWT.Modify, listener);
         credentialsComposite.addUserNameListener(SWT.Modify, listener);
@@ -167,6 +209,16 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
 
         if (valid && (null == endPointText.getText() || endPointText.getText().isEmpty())) {
             errorMessage = UTIL.getString("Common.EndPoint.Error.Message"); //$NON-NLS-1$
+            valid = false;
+        }
+
+        if (valid && (null == endPointNameText.getText() || endPointNameText.getText().isEmpty())) {
+            errorMessage = UTIL.getString("Common.EndPointName.Error.Message"); //$NON-NLS-1$
+            valid = false;
+        }
+
+        if (valid && (null == bindingTypeText.getText() || bindingTypeText.getText().isEmpty())) {
+            errorMessage = UTIL.getString("Common.EndPointBinding.Error.Message"); //$NON-NLS-1$
             valid = false;
         }
 
@@ -205,6 +257,16 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
         if (null != endPoint) {
             endPointText.setText(endPoint);
         }
+
+        String endPointName = props.getProperty(IWSProfileConstants.END_POINT_NAME_PROP_ID);
+        if (null != endPointName) {
+            endPointNameText.setText(endPointName);
+        }
+
+        String bindingType = props.getProperty(IWSProfileConstants.SOAP_BINDING);
+        if (null != bindingType) {
+            bindingTypeText.setText(bindingType);
+        }
     }
 
     /**
@@ -216,8 +278,10 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
     protected Properties collectProperties() {
         Properties result = super.collectProperties();
         if (null == result) {
-            result = new Properties();
+            IConnectionProfile profile = getConnectionProfile();
+            result = (Properties) profile.getBaseProperties().clone();
         }
+
         result.setProperty(IWSProfileConstants.WSDL_URI_PROP_ID, urlText.getText());
         result.setProperty(ICredentialsCommon.SECURITY_TYPE_ID, credentialsComposite.getSecurityOption().name());
         if( credentialsComposite.getUserName() != null ) {
@@ -226,7 +290,10 @@ public class WSSoapPropertyPage extends ProfileDetailsPropertyPage implements IC
         if( credentialsComposite.getPassword() != null) {
         	result.setProperty(ICredentialsCommon.PASSWORD_PROP_ID, credentialsComposite.getPassword());
         }
+
         result.setProperty(IWSProfileConstants.END_POINT_URI_PROP_ID, endPointText.getText());
+        result.setProperty(IWSProfileConstants.END_POINT_NAME_PROP_ID, endPointNameText.getText());
+        result.setProperty(IWSProfileConstants.SOAP_BINDING, bindingTypeText.getText());
 
         return result;
     }

--- a/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/ui/i18n.properties
+++ b/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/ui/i18n.properties
@@ -63,8 +63,12 @@ a source model via the 'Modeling > Set Connection Profile' action. This 'Endpoin
 WSSoapProfileDetailsWizardPage.validatingWsdlMessage=Validating the WSDL ...
 WSSoapProfileDetailsWizardPage.validationSuccessfulWsdlMessage=The WSDL has been successfully pinged and validated
 WSSoapProfileDetailsWizardPage.validationErrorWsdlMessage=Failed to validate the WSDL
-WSSoapPropertyPage.endPointName=End Point
-WSSoapPropertyPage.endPoint.ToolTip=The SOAP end point (or port) used by the server
+WSSoapPropertyPage.endPointName=End Point Address
+WSSoapPropertyPage.endPoint.ToolTip=The SOAP end point address used by the server
+WSSoapPropertyPage.endPointNameName=End Point
+WSSoapPropertyPage.endPoint.ToolTip=The SOAP end port name used by the server
+WSSoapPropertyPage.endPointBindingLabel=Binding Type
+WSSoapPropertyPage.endPointBinding.ToolTip=The SOAP end point binding type
 
 FlatFileUrlProfileDetailsWizardPage.Name=Flat File URL Connection Properties
 FlatFileUrlProfileDetailsWizardPage.InvalidFile.Message=File URL [{0}] is invalid.
@@ -107,6 +111,8 @@ Common.URLorFILE.Invalid.Message=The URL is not valid or the File does not exist
 Common.Context.Factory.Error.Message=The Context Factory cannot be empty
 Common.Security.Error.Message=None, HTTPBasic, and WSSecurity are the only valid values for Security Type
 Common.EndPoint.Error.Message=The WSDL EndPoint cannot be empty
+Common.EndPointName.Error.Message=The WSDL EndPoint cannot be empty
+Common.EndPointBinding.Error.Message=The WSDL EndPoint Binding Type cannot be empty
 Common.EndPoint.Invalid.Message=The EndPoint is not valid
 
 Common.HOST_LBL_UI_=&Host

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidDataSourceFactory.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidDataSourceFactory.java
@@ -56,6 +56,9 @@ public class TeiidDataSourceFactory {
          ModelResource modelResource = ModelUtil.getModelResource(model, true);
          ConnectionInfoProviderFactory manager = new ConnectionInfoProviderFactory();
          IConnectionInfoProvider connInfoProvider = manager.getProvider(modelResource);
+         if (connInfoProvider == null)
+             return null;
+
          IConnectionProfile modelConnectionProfile = connInfoProvider.getConnectionProfile(modelResource);
          
          if (modelConnectionProfile == null)

--- a/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/Messages.java
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/Messages.java
@@ -14,7 +14,6 @@ import org.eclipse.osgi.util.NLS;
  */
 public class Messages  extends NLS {
 
-
     public static String Add;
     public static String AddAsNewColumn;
     public static String AddAsNewElement;
@@ -127,7 +126,9 @@ public class Messages  extends NLS {
     public static String Status_ViewModelNameCannotBeNullOrEmpty;
     public static String Statis_ViewModelAlreadyExists;
     public static String Status_ViewModelDoesNotExistAndWillBeCreated;
-    
+    public static String Status_ConnectionProfileMissing;
+    public static String Status_ConnectionProfilePropertyMissing;
+
     public static String Error_Creating_0_Model_1_FromWsdl;
     public static String Error_DeterminingSourceModelHas_0_Procedure;
     public static String Error_DeterminingSourceModelHasProfile;

--- a/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/messages.properties
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/messages.properties
@@ -60,8 +60,8 @@ MultipleOperationsSelected_msg=Multiple operations selected
 Name=Name
 New=New...
 NoHeaderMessage=Default Service Mode == PAYLOAD : No header definition required
-NoOperationsSelected=No Operations Selected
-NoOperationsSelected_msg=No Operations Selected
+NoOperationsSelected=No operations have been selected or the connection profile is invalid
+NoOperationsSelected_msg=No operations have been selected or the connection profile is invalid
 
 Operation=Operation
 Operations=Operations
@@ -119,6 +119,8 @@ Status_SourceModelNameCannotBeNullOrEmpty=Source model name cannot be null or em
 Status_ViewModelNameCannotBeNullOrEmpty=View model name cannot be null or empty. Please select an existing model in your workspace or enter a valid name for new model
 Statis_ViewModelAlreadyExists=View model {0} already exists and will not be created. All generated procedures will be added to this model
 Status_ViewModelDoesNotExistAndWillBeCreated=View model {0} does not exist and will be created and contain your generated procedures.
+Status_ConnectionProfileMissing=A Connection Profile has not been selected
+Status_ConnectionProfilePropertyMissing=Connection Profile is invalid since it does not contain the required property {0}
 
 Error_Creating_0_Model_1_FromWsdl=Error creating {0} model {1} and procedures for specified WSDL
 Error_DeterminingSourceModelHas_0_Procedure=Error determining if source model has {0} procedure

--- a/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/panels/WsdlOperationsPanel.java
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/panels/WsdlOperationsPanel.java
@@ -44,14 +44,15 @@ import org.teiid.designer.modelgenerator.wsdl.model.Fault;
 import org.teiid.designer.modelgenerator.wsdl.model.Model;
 import org.teiid.designer.modelgenerator.wsdl.model.ModelGenerationException;
 import org.teiid.designer.modelgenerator.wsdl.model.Operation;
-import org.teiid.designer.modelgenerator.wsdl.model.Port;
 import org.teiid.designer.modelgenerator.wsdl.model.WSDLElement;
 import org.teiid.designer.modelgenerator.wsdl.ui.Messages;
 import org.teiid.designer.modelgenerator.wsdl.ui.ModelGeneratorWsdlUiConstants;
 import org.teiid.designer.modelgenerator.wsdl.ui.util.ModelGeneratorWsdlUiUtil;
 import org.teiid.designer.modelgenerator.wsdl.ui.wizards.WSDLImportWizardManager;
 import org.teiid.designer.modelgenerator.wsdl.ui.wizards.soap.WsdlDefinitionPage;
+import org.teiid.designer.query.proc.wsdl.model.IPort;
 import org.teiid.designer.ui.common.util.WidgetFactory;
+import org.teiid.designer.ui.common.util.WidgetUtil;
 import org.teiid.designer.ui.common.viewsupport.UiBusyIndicator;
 import org.teiid.designer.ui.common.widget.Label;
 
@@ -379,41 +380,42 @@ public class WsdlOperationsPanel implements FileUtils.Constants, CoreStringUtil.
             public void run() {
 
                 panelStatus = Status.OK_STATUS;
-		try {
+                try {
                     wsdlModel = importManager.getWSDLModel();
-		} catch (ModelGenerationException e) {
+                } catch (ModelGenerationException e) {
                     wsdlModel = null;
-			Status exStatus = new Status(IStatus.ERROR, PLUGIN_ID, 0,
-				Messages.WsdlOperationsPage_dialog_wsdlParseError_msg, e);
+                    Status exStatus = new Status(IStatus.ERROR, PLUGIN_ID, 0,
+                                                 Messages.WsdlOperationsPage_dialog_wsdlParseError_msg, e);
                     Shell shell = parentComposite.getShell();
-			ErrorDialog.openError(shell, null, Messages.WsdlOperationsPage_dialog_wsdlParseError_title, exStatus);
+                    ErrorDialog.openError(shell, null, Messages.WsdlOperationsPage_dialog_wsdlParseError_title, exStatus);
                     panelStatus = exStatus;
                     operationsViewer.getTable().clearAll();
                     operationsViewer.setInput(new Object());
                 }
-                
+
                 // Set the default binding label
                 Properties properties = importManager.getConnectionProfile().getBaseProperties();
                 String binding = properties.getProperty(IWSProfileConstants.SOAP_BINDING);
                 if (binding == null)
-                    binding = Port.SOAP11;
-                
-                defaultBindingText.setText(binding);
-                    
+                    binding = IPort.SOAP11;
+
+                WidgetUtil.setText(defaultBindingText, binding);
+
                 // Populate the operations table
-                if( wsdlModel != null ) {
-                    String portName = properties.getProperty(IWSProfileConstants.END_POINT_NAME_PROP_ID);
-                    Operation[] operations = wsdlModel.getModelableOperations(portName);
-                    operationsViewer.setInput(new OperationsContainer(operations));
-                    operationsViewer.refresh(true);
+                String portName = properties.getProperty(IWSProfileConstants.END_POINT_NAME_PROP_ID);
+                Operation[] operations = new Operation[0];
+                if (wsdlModel != null && portName != null) {
+                    operations = wsdlModel.getModelableOperations(portName);
                 }
-                
+                operationsViewer.setInput(new OperationsContainer(operations));
+                operationsViewer.refresh(true);
+
                 importManager.setSelectedOperations(new ArrayList());
-		setAllNodesSelected(true);
-		updateImportManager();
+                setAllNodesSelected(true);
+                updateImportManager();
             }
         });
-	}
+    }
 	
 	private void handleDefaultServiceModeSelected() {
 		this.importManager.setTranslatorDefaultServiceMode(this.defaultServiceModeCombo.getText());

--- a/plugins/org.teiid.designer.modelgenerator.wsdl/src/org/teiid/designer/modelgenerator/wsdl/model/impl/ModelImpl.java
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl/src/org/teiid/designer/modelgenerator/wsdl/model/impl/ModelImpl.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import org.eclipse.xsd.XSDSchema;
 import org.jdom.Namespace;
 import org.teiid.core.designer.util.CoreArgCheck;
@@ -89,8 +88,10 @@ public class ModelImpl implements Model {
     
     @Override
 	public Operation[] getModelableOperations(String portName) {
-    	Map<String, Operation> existingMap = modelableOperationsMaps.get(portName);
-    	
+        Map<String, Operation> existingMap = modelableOperationsMaps.get(portName);
+        if (existingMap == null)
+            return new Operation[0];
+
     	int nValues = existingMap.values().size();
     	List<Operation> ops = new ArrayList<Operation>(existingMap.values());
     	Collections.sort(ops, new OperationComparator());

--- a/plugins/org.teiid.designer.ui.common/src/org/teiid/designer/ui/common/util/WidgetUtil.java
+++ b/plugins/org.teiid.designer.ui.common/src/org/teiid/designer/ui/common/util/WidgetUtil.java
@@ -110,6 +110,8 @@ public final class WidgetUtil implements
     
     public static final int TEXT_COLOR_DEFAULT = 0;
     public static final int TEXT_COLOR_BLUE = 1;
+
+    private static final String EMPTY_STR = ""; //$NON-NLS-1$
     
 
     // ============================================================================================================================
@@ -898,6 +900,24 @@ public final class WidgetUtil implements
         }
         // Set text on Combo
         combo.setText(text);
+    }
+
+    /**
+     * Set the value of a {@link Text}'s text safely.
+     * If the textValue is null then an empty string
+     * is set instead.
+     *
+     * @param text widget
+     * @param textValue value to be set as text
+     */
+    public static void setText(Text text, String textValue) {
+        if (text == null)
+            return;
+
+        if (textValue == null)
+            textValue = EMPTY_STR;
+
+        text.setText(textValue);
     }
 
     /**


### PR DESCRIPTION
- WSSoapPropertyPage
  - Display the EndPointName and the BindingType properties since they are
    necessary for the WSDL SOAP wizard
  - When replacing the existing properties, rather than creating a new
    Properties object, clone the original. This allows overwriting of
    existing property values but avoid wiping out other values
  - Ensure the EndPointName and BindingType properties are included in the
    connection profile properties
- TeiidDataSourceFactory
  - Avoid exceptions if the connection profile returned by the model
    resource is invalid
- WsdlDefinitionPage
- ImportManagerValidator
- WsdlOperationsPanel
  - Improves the WSDL importer's validation and error message display if the
    connection profile is invalid
  - Specifically validate the connection profile properties to ensure the
    minimum required properties are present
  - If the connection profile is invalid then set the wizard page status
    appropriately
  - If the wsdlModel is not parseable (unconnected) or the port name is
    missing then refresh the operations panel to display nothing
- ModelImpl
  - Avoids assuming the port name will return a sensible operations map
- WidgetUtil
  - Provides a method for setting the text value of a Text widget that
    ensures the value is not null since this throws an SWT exception
