### PR TITLE
TEIIDDES-1913 Teiid Connection Importer now checking types which cannot be imported

### DIFF
--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
@@ -86,7 +86,8 @@ public class Messages extends NLS {
     public static String selectDataSourcePage_dataSourceGroupText;
     public static String selectDataSourcePage_dataSourcePropertiesGroupText;
     public static String selectDataSourcePage_NoSourceSelectedMsg;
-
+    public static String selectDataSourcePage_CannotImportSourceTypeMsg;
+    
     public static String SelectTranslatorPage_title;
     public static String SelectTranslatorPage_dsNameLabel;
     public static String SelectTranslatorPage_dsTypeLabel;

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
@@ -77,6 +77,7 @@ selectDataSourcePage_title=Select the DataSource to use for the import
 selectDataSourcePage_dataSourceGroupText=Data Sources
 selectDataSourcePage_dataSourcePropertiesGroupText=Data Source Properties
 selectDataSourcePage_NoSourceSelectedMsg=Please select a DataSource from the available list
+selectDataSourcePage_CannotImportSourceTypeMsg=Sources of type "{0}" cannot be imported with this wizard.  Please consult the Teiid documentation for manual modeling instructions. 
 
 SelectTranslatorPage_title=Select the translator and target model for the import
 SelectTranslatorPage_dsNameLabel=DataSource:

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourceManager.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourceManager.java
@@ -379,7 +379,8 @@ public class DataSourceManager implements UiConstants {
      		} else  {
     			if(   driverName.equals(TranslatorHelper.TEIID_FILE_DRIVER_84UP) || driverName.equals(TranslatorHelper.TEIID_GOOGLE_DRIVER_84UP)
     			   || driverName.equals(TranslatorHelper.TEIID_INFINISPAN_DRIVER_84UP) || driverName.equals(TranslatorHelper.TEIID_LDAP_DRIVER_84UP)
-    			   || driverName.equals(TranslatorHelper.TEIID_SALESORCE_DRIVER_84UP) || driverName.equals(TranslatorHelper.TEIID_WEBSERVICE_DRIVER_84UP)) {
+    			   || driverName.equals(TranslatorHelper.TEIID_SALESORCE_DRIVER_84UP) || driverName.equals(TranslatorHelper.TEIID_WEBSERVICE_DRIVER_84UP)
+    			   || driverName.equals(TranslatorHelper.TEIID_MONGODB_DRIVER_84UP)) {
     				isRarDriver = true;
     			}
     		}

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/SelectDataSourcePage.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/SelectDataSourcePage.java
@@ -7,12 +7,17 @@
  */
 package org.teiid.designer.teiidimporter.ui.wizard;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.teiidimporter.ui.Messages;
 import org.teiid.designer.teiidimporter.ui.UiConstants;
 import org.teiid.designer.teiidimporter.ui.panels.DataSourcePanel;
@@ -34,6 +39,14 @@ public class SelectDataSourcePage extends AbstractWizardPage
 
     private static final String EMPTY_STR = ""; //$NON-NLS-1$
     private static final String SERVER_PREFIX = "Server: "; //$NON-NLS-1$
+    
+    // Source types that cannot be imported with this wizard
+    private static final List<String> DISALLOWED_SOURCES;
+    static {
+    	DISALLOWED_SOURCES = new ArrayList<String>();
+    	DISALLOWED_SOURCES.add("ldap");  //$NON-NLS-1$
+    	DISALLOWED_SOURCES.add("mongodb"); //$NON-NLS-1$
+    }
 
     private TeiidImportManager importManager;
 
@@ -120,6 +133,10 @@ public class SelectDataSourcePage extends AbstractWizardPage
         return this.importManager.getDataSourceName();
     }
     
+    private String getSelectedDataSourceDriverName() {
+        return this.importManager.getDataSourceDriverName();
+    }
+    
     @Override
     public void setVisible( boolean visible ) {
         if (visible) {
@@ -140,7 +157,16 @@ public class SelectDataSourcePage extends AbstractWizardPage
             setThisPageComplete(Messages.selectDataSourcePage_NoSourceSelectedMsg, ERROR);
             return false;
         }
-        
+         
+        // The importer cannot be used for some types - the DDL cannot be generated.  Manual modeling is required.
+        String selectedDataSourceDriverName = getSelectedDataSourceDriverName();
+        if(!CoreStringUtil.isEmpty(selectedDataSourceDriverName)) {
+        	String driverNameLC = selectedDataSourceDriverName.toLowerCase();
+        	if(DISALLOWED_SOURCES.contains(driverNameLC)) {  
+                setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_CannotImportSourceTypeMsg, driverNameLC) , ERROR);
+                return false;        		
+        	}
+        }
         setThisPageComplete(EMPTY_STR, NONE);
         return true;
     }


### PR DESCRIPTION
- excludes ldap and mongodb from being allowed to complete.  teiid does not generate DDL for them.
