### PR TITLE
TEIIDDES-1918 Resolve type mapping issue in RelationalModelProcessor

### DIFF
--- a/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/RelationalModelProcessorImpl.java
+++ b/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/RelationalModelProcessorImpl.java
@@ -1446,14 +1446,14 @@ public class RelationalModelProcessorImpl implements ModelerJdbcRelationalConsta
             jdbcType = Types.BINARY;
         }
 
-        // First look up by type code ...
-        result = findType(jdbcType, problems);
+        // First look up by name
+        result = findType(typeName, problems);
         if (result != null) {
             return result;
         }
 
-        // Still haven't found one, so look it up by name ...
-        result = findType(typeName, problems);
+        // Still haven't found one, so look it up by typeCode ...
+        result = findType(jdbcType, problems);
         return result;
     }
 

--- a/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/util/RelationalTypeMappingImpl.java
+++ b/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/util/RelationalTypeMappingImpl.java
@@ -128,10 +128,16 @@ public class RelationalTypeMappingImpl implements RelationalTypeMapping {
 	public EObject getDatatype( final String jdbcTypeName ) throws ModelerCoreException {
     	EObject result = null;
         if (jdbcTypeName != null) {
-        	Integer typeCode = SQL_TYPE_MAPPING.get(jdbcTypeName.toUpperCase());
-	        if (typeCode != null) {
-	        	result = getDatatype(typeCode);
-	        }
+        	// Look for direct match to Built-in types first
+        	result = this.datatypeManager.getBuiltInDatatype(jdbcTypeName);
+
+        	// No direct match, so look for jdbc type
+        	if(result == null) {
+            	Integer typeCode = SQL_TYPE_MAPPING.get(jdbcTypeName.toUpperCase());
+    	        if (typeCode != null) {
+    	        	result = getDatatype(typeCode);
+    	        }
+        	}
         }
         if (result == null) {
             result = findDatatype(DatatypeConstants.BuiltInNames.OBJECT);


### PR DESCRIPTION
- looks up type by name first in RelationalModelProcessor
- in RelationalTypeMapping, now checks against builtIn types first - and uses if there is a direct match.
