### PR TITLE
TEIIDDES-1927 Change translator not recognized if VDB is re-executed

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/vdb/ExecuteVdbWorker.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/vdb/ExecuteVdbWorker.java
@@ -90,11 +90,10 @@ public class ExecuteVdbWorker implements VdbConstants {
 			if (teiidServer != null) {
 				IStatus connectStatus = teiidServer.ping();
 				if (connectStatus.isOK()) {
+					// Deploy the VDB
+                    DeployVdbAction.deployVdb(teiidServer, selectedVdb);
+                    
 				    String vdbName = selectedVdb.getFullPath().removeFileExtension().lastSegment();
-                    if (! teiidServer.hasVdb(vdbName)) {
-                        DeployVdbAction.deployVdb(teiidServer, selectedVdb);
-                    }
-
                     if (teiidServer.isVdbActive(vdbName)) {
                         executeVdb(DqpPlugin.getInstance().getServerManager().getDefaultServer(), vdbName);
                     } else if (teiidServer.isVdbLoading(vdbName)) {


### PR DESCRIPTION
- On VDB Execution the vdb is always deployed now.  Change of translator (and presumably other changes) were not causing re-deploy upon re-execution before.
