### PR TITLE
TEIIDDES-1931: Stop stackoverflow exceptions from the TeiidServerManager

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/ModelerCore.java
@@ -2267,8 +2267,7 @@ public class ModelerCore extends Plugin implements DeclarativeTransactionManager
                     }
 
                     @Override
-                    public void process(ITeiidServerManager instance,
-                                        IConfigurationElement element) {
+                    public void process(ITeiidServerManager instance, IConfigurationElement element) {
                         CoreArgCheck.isNotNull(instance);
 
                         if (teiidServerManager != null) {
@@ -2279,8 +2278,14 @@ public class ModelerCore extends Plugin implements DeclarativeTransactionManager
                             throw new IllegalStateException();
                         }
 
+                        /*
+                         * Need to assign the new instance to the singleton here prior to
+                         * its restoration since the saved server instances use it,
+                         * eg. notifying listeners. This scenario is not protected by the
+                         * synchronized mutexObject since it would be the same thread.
+                         */
                         teiidServerManager = instance;
-                        teiidServerManager.restoreState();
+                        instance.restoreState();
                     }
                 };
 

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidServerManager.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/TeiidServerManager.java
@@ -650,6 +650,8 @@ public final class TeiidServerManager implements ITeiidServerManager {
         ITeiidServer defaultServer = null;
 
         try {
+            this.notifyListeners = false;
+
             if (this.stateLocationPath == null || ! stateFileExists()) {
                 // Started will be called from the finally clause.
                 return;
@@ -806,6 +808,7 @@ public final class TeiidServerManager implements ITeiidServerManager {
         } catch (Exception e) {
             Util.log(e);
         } finally {
+            this.notifyListeners = true;
             this.state = RuntimeState.STARTED;
             initialiseManagers();
 


### PR DESCRIPTION
- ModelerCore
  - As soon as a new instance of TeiidServerManager is constructed assign
    it to the singleton so that no other instances are attempted to be
    constructed. This can happen if restoreState calls listeners which in
    turn require the server manager through ModelerCore. The sync mutex
    object will not prevent this use-case since it would occur in the same
    thread.
- TeiidServerManager
  - While restoring stop any notification of listeners from the initialising
    Teiid instances. Since the manager is in the middle of restoring
    unexpected behaviour can occur from the listeners including stack
    overflow exceptions.
