### PR TITLE
TEIIDDES-1935: Tidy up paths through setting the default server

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
@@ -224,7 +224,10 @@ setDefaultServerActionDisconnectOldTitle=Disconnect Current Default Teiid Instan
 setDefaultServerActionDisconnectOldMessage=Do you wish to disconnect from {0} before switching to new default Teiid Instance?
 defaultServerChangedTitle=Default Instance Changed
 defaultServerChangedMessage=The default teiid instance has been changed to {0}
- 
+defaultServerUnchangedTitle=Default Instance unchanged
+defaultServerUnchangedMessage1Server=Only 1 server is configured therefore the default teiid instance remains as {0}
+defaultServerUnchangedMessageMultiServer=The default teiid instance remains as {0}
+
 serverEmptyUserMsg = The user name cannot be empty
 serverExistsMsg = {0} already exists so it cannot be added
 serverInvalidUrlMsg = The  value "{0}" is not a valid Teiid URL

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/SetDefaultServerAction.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/SetDefaultServerAction.java
@@ -94,6 +94,34 @@ public class SetDefaultServerAction extends BaseSelectionListenerAction implemen
         }
         
         ITeiidServer currentDefaultServer = this.getServerManager().getDefaultServer();
+        if (currentDefaultServer != null && currentDefaultServer.equals(selectedServer)) {
+            /*
+             * Selected is the same as current so nothing more to do
+             */
+
+            String title = UTIL.getString("defaultServerUnchangedTitle"); //$NON-NLS-1$
+            String message = null;
+            if (getServerManager().getServers().size() == 1) {
+                /*
+                 * User would not have been shown a server selection chooser
+                 * since only one server is available. In this case, the server
+                 * unchanged message should be clarified slightly.
+                 */
+                message = UTIL.getString("defaultServerUnchangedMessage1Server", //$NON-NLS-1$
+                                                            currentDefaultServer.getDisplayName());
+            }
+            else {
+                /*
+                 * More than 1 server so the user actively chose to keep this server rather
+                 * than change it
+                 */
+                message = UTIL.getString("defaultServerUnchangedMessageMultiServer", //$NON-NLS-1$
+                                                            currentDefaultServer.getDisplayName());
+            }
+
+            MessageDialog.openInformation(getShell(), title, message);
+            return;
+        }
         
         /*
          * If a server version change is occurring then tell the user and ask them if its


### PR DESCRIPTION
- If the server selected is the same as the current then a more appropriate
  message is displayed rather than implying a change has been made
- If there is only 1 server then the user had no recourse to modify it and
  as such an appropriate message should be displayed
- If there are multiple servers then the user actively selected the same
  server and as such no change should be displayed
