### PR TITLE
JBIDE-16133: Provide better feedback for incorrect admin password

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditor.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/editor/TeiidServerEditor.java
@@ -272,16 +272,20 @@ public class TeiidServerEditor extends EditorPart implements IManagedLoading {
 
                 getServerManager().addListener(excutionConfigListener);
 
-                TeiidServerAdapterFactory adapterFactory = new TeiidServerAdapterFactory();
-                if (parentServer.getServerState() == IServer.STATE_STARTED)
-                    // If server is started we can be more adventurous in what to display since we can ask
-                    // the server whether teiid has been installed.
-                    teiidServer = adapterFactory.adaptServer(parentServer, ServerOptions.ADD_TO_REGISTRY);
-                else {
-                    // Cannot ask a lot except whether the server is a JBoss Server
-                    teiidServer = adapterFactory.adaptServer(parentServer,
+                try {
+                    TeiidServerAdapterFactory adapterFactory = new TeiidServerAdapterFactory();
+                    if (parentServer.getServerState() == IServer.STATE_STARTED)
+                        // If server is started we can be more adventurous in what to display since we can ask
+                        // the server whether teiid has been installed.
+                        teiidServer = adapterFactory.adaptServer(parentServer, ServerOptions.ADD_TO_REGISTRY);
+                    else {
+                        // Cannot ask a lot except whether the server is a JBoss Server
+                        teiidServer = adapterFactory.adaptServer(parentServer,
                                                              ServerOptions.NO_CHECK_CONNECTION,
                                                              ServerOptions.ADD_TO_REGISTRY);
+                    }
+                } catch (Exception ex) {
+                    DqpPlugin.handleException(ex);
                 }
 
                 if (teiidServer != null) {

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/views/content/TeiidErrorNode.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/views/content/TeiidErrorNode.java
@@ -50,4 +50,9 @@ public class TeiidErrorNode extends TeiidContentNode<ITeiidContainerNode<?>> {
     public ITeiidServer getTeiidServer() {
         return teiidServer;
     }
+
+    @Override
+    public String toString() {
+        return text;
+    }
 }

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/JBossServerUtil.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/JBossServerUtil.java
@@ -7,7 +7,6 @@
 */
 package org.teiid.designer.runtime.adapter;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import org.eclipse.core.runtime.IStatus;
@@ -28,8 +27,9 @@ public class JBossServerUtil {
      * @param jbossServer
      * 
      * @return true if server can be connected
+     * @throws Exception
      */
-    public static boolean isJBossServerConnected(IServer parentServer, JBossServer jbossServer) {
+    public static boolean isJBossServerConnected(IServer parentServer, JBossServer jbossServer) throws Exception {
         if (!serverStarted(parentServer)) 
             return false;
 
@@ -39,8 +39,9 @@ public class JBossServerUtil {
     /**
      * @param jbossServer
      * @return
+     * @throws Exception
      */
-    protected static boolean isHostConnected(String host, int port) {
+    protected static boolean isHostConnected(String host, int port) throws Exception {
         Socket socket = null;
         InetSocketAddress endPoint = new InetSocketAddress(host, port);
 
@@ -54,17 +55,10 @@ public class JBossServerUtil {
             socket.connect(endPoint, 1024);
 
             return true;
-        } catch (Exception ex) {
-            // Connection failed - no need to log exception
-            return false;
         } finally {
             if (socket != null && socket.isConnected()) {
-                try {
-                    socket.close();
-                    socket = null;
-                } catch (IOException ex) {
-                    DqpPlugin.Util.log(IStatus.WARNING, ex, DqpPlugin.Util.getString("jbossServerConnectionFailureMessage", endPoint)); //$NON-NLS-1$
-                }
+                socket.close();
+                socket = null;
             }
         }
     }
@@ -76,8 +70,9 @@ public class JBossServerUtil {
      * @param jbossServer
      * 
      * @return true is server has teiid support, false otherwise
+     * @throws Exception
      */
-    public static boolean isTeiidServer(IServer parentServer, JBossServer jbossServer) {
+    public static boolean isTeiidServer(IServer parentServer, JBossServer jbossServer) throws Exception {
         if (!serverStarted(parentServer)) 
             return false;
 

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/TeiidServerAdapterFactory.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/TeiidServerAdapterFactory.java
@@ -71,8 +71,9 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
      * @param options 
      * 
      * @return {@link ITeiidServer} or null
+     * @throws Exception
      */
-    public ITeiidServer adaptServer(final IServer server, ServerOptions... options) {
+    public ITeiidServer adaptServer(final IServer server, ServerOptions... options) throws Exception {
         if (! getTeiidServerManager().isStarted())
             return null;
 
@@ -96,8 +97,9 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
      * @param options
      * 
      * @return
+     * @throws Exception
      */
-    private ITeiidServer adaptJBossServer(IServer parentServer, JBossServer jbossServer, ServerOptions... options) {
+    private ITeiidServer adaptJBossServer(IServer parentServer, JBossServer jbossServer, ServerOptions... options) throws Exception {
         ITeiidServer teiidServer = null;
         
         List<ServerOptions> optionList = Collections.emptyList(); 
@@ -147,9 +149,10 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
      * @param jboss7Server
      * @param options
      * 
+     * @throws Exception
      * @return
      */
-    private ITeiidServer adaptJBoss7Server(IServer parentServer, JBoss7Server jboss7Server, ServerOptions... options) {
+    private ITeiidServer adaptJBoss7Server(IServer parentServer, JBoss7Server jboss7Server, ServerOptions... options) throws Exception {
         ITeiidServer teiidServer = null;
         
         List<ServerOptions> optionList = Collections.emptyList(); 
@@ -201,8 +204,10 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
      * @param options
      * 
      * @return new {@link ITeiidServer}
+     * @throws Exception
      */
-    private ITeiidServer createJboss7TeiidServer(final IServer parentServer, final JBoss7Server jboss7Server, ServerOptions... options) {
+    private ITeiidServer createJboss7TeiidServer(final IServer parentServer, final JBoss7Server jboss7Server, ServerOptions... options) 
+            throws Exception {
         TeiidServerFactory factory = new TeiidServerFactory();
         ITeiidServer teiidServer = factory.createTeiidServer(JBoss7ServerUtil.getTeiidRuntimeVersion(parentServer, jboss7Server),
                                                                                         getTeiidServerManager(),
@@ -260,8 +265,9 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
      * @param server
      * 
      * @return true if connected
+     * @throws Exception
      */
-    public boolean isParentServerConnected(IServer server) {
+    public boolean isParentServerConnected(IServer server) throws Exception {
         if (server.getServerState() != IServer.STATE_STARTED)
             return false;
         

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/i18n.properties
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/i18n.properties
@@ -89,7 +89,8 @@ errorSavingServerRegistry = Unable to save server registry to file "{0}"
 errorOnPreviewManagerShutdown = An error shutting down the Preview Manager occurred.
 serverExistsMsg = A server with URL "{0}" already exists.
 serverParentNotConnectedErrorMsg = The parent JBoss Server is not started.
-serverReconnectErrorMsg = Error connecting to Teiid {0}.
+serverReconnectErrorMsg = Cannot establish a connection to the Teiid instance {0}.
+serverAdminInitError = Cannot initiaise the admin connection.
 serverManagerRegistryRemoveUnexpectedError = Unexpected error unregistering server with URL "{0}"
 serverManagerRegistryUpdateAddError = Problem adding new version of server being updated. {0}
 serverManagerRegistryUpdateRemoveError = Problem removing old version of server being updated. {0}
@@ -144,3 +145,8 @@ TeiidURL.invalid_ipv6_hostport=The IPv6 host:port ''{0}'' is not valid. {1}
 TeiidURL.invalid_hostport=The host:port ''{0}'' is not valid. {1}
 TeiidURL.non_numeric_port=The port ''{0}'' is a non-numeric value.
 TeiidURL.port_out_of_range=The port ''{0}'' is out of range.
+
+# TeiidParentServerListener
+TeiidParentServerListener.initTeiidServerException.title = Teiid Instance Initialisation Failure
+TeiidParentServerListener.initTeiidServerException.message = The Teiid Instance for the server failed to initialise.
+TeiidParentServerListener.initTeiidServerException.reason = The intialisation produced an exception, which can occur due to incorrect security credentials. Please review the exception messages by clicking the Details button.


### PR DESCRIPTION
- JBoss[7]ServerUtil
- TeiidServerAdapterFactory
  - Rather than catching JBoss exceptions (may be caused by incorrect
    security credentials) throw them instead and force UI components to
    catch and process them
- TeiidServer
  - Better handle exceptions thrown when failing to connect to teiid instance
- TeiidServerEditor
- TeiidParentServerListener
  - Rather than just logging exceptions thrown when initialising the teiid
    instance, get the exception back to the user
- DqpPlugin
  - API for handling exceptions by displaying them using an ErrorDialog
  - This is not ideal given that the DqpPlugin is technically a non-UI
    plugin despite depending on org.eclipse.ui.
  - At some point, this needs refactoring to set a UI provider for displaying
    exceptions in the UI.
