### PR TITLE
TEIIDDES-1942 Correct type resolution issue in RelationalModelProcessor

### DIFF
--- a/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/RelationalModelProcessorImpl.java
+++ b/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/impl/RelationalModelProcessorImpl.java
@@ -1445,15 +1445,25 @@ public class RelationalModelProcessorImpl implements ModelerJdbcRelationalConsta
             //for mysql a long may also be a valid representation
             jdbcType = Types.BINARY;
         }
+        
+    	// First try direct match to Built-in types
+    	try {
+			result = this.datatypeManager.getBuiltInDatatype(typeName);
+		} catch (ModelerCoreException ex) {
+            JdbcPlugin.Util.log(ex);
+		}
+    	if(result != null) {
+    		return result;
+    	}
 
-        // First look up by name
-        result = findType(typeName, problems);
+        // Look up by type code ...
+        result = findType(jdbcType, problems);
         if (result != null) {
             return result;
         }
 
-        // Still haven't found one, so look it up by typeCode ...
-        result = findType(jdbcType, problems);
+        // Still haven't found one, so look it up by name ...
+        result = findType(typeName, problems);
         return result;
     }
 

--- a/plugins/org.teiid.designer.jdbc.ui/src/org/teiid/designer/jdbc/ui/wizards/JdbcSourceSelectionPage.java
+++ b/plugins/org.teiid.designer.jdbc.ui/src/org/teiid/designer/jdbc/ui/wizards/JdbcSourceSelectionPage.java
@@ -733,7 +733,10 @@ public class JdbcSourceSelectionPage extends AbstractWizardPage
         }
 
         public JdbcSource getJdbcSource() {
-            return mgr.getJdbcSource(latestProfile);
+        	if(latestProfile!=null) {
+        		return mgr.getJdbcSource(latestProfile);
+        	}
+        	return null;
         }
     }
 }

--- a/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/util/RelationalTypeMappingImpl.java
+++ b/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/util/RelationalTypeMappingImpl.java
@@ -128,16 +128,10 @@ public class RelationalTypeMappingImpl implements RelationalTypeMapping {
 	public EObject getDatatype( final String jdbcTypeName ) throws ModelerCoreException {
     	EObject result = null;
         if (jdbcTypeName != null) {
-        	// Look for direct match to Built-in types first
-        	result = this.datatypeManager.getBuiltInDatatype(jdbcTypeName);
-
-        	// No direct match, so look for jdbc type
-        	if(result == null) {
-            	Integer typeCode = SQL_TYPE_MAPPING.get(jdbcTypeName.toUpperCase());
-    	        if (typeCode != null) {
-    	        	result = getDatatype(typeCode);
-    	        }
-        	}
+        	Integer typeCode = SQL_TYPE_MAPPING.get(jdbcTypeName.toUpperCase());
+	        if (typeCode != null) {
+	        	result = getDatatype(typeCode);
+	        }
         }
         if (result == null) {
             result = findDatatype(DatatypeConstants.BuiltInNames.OBJECT);


### PR DESCRIPTION
- Reverts previous changes in RelationalModelProcessorImpl and RelationalTypeMappingImpl.  It had un-intended consequence of returning Object datatype in name lookup method.
- Now in RelationalModelProcessorImpl, look for exact match to built-in types first.  If exact match is not found then the original logic is used.
