### PR TITLE
TEIIDDES-1966 Resolves several issues with VDB Editor multi-source binding panel

### DIFF
--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbSource.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbSource.java
@@ -7,10 +7,11 @@
 */
 package org.teiid.designer.vdb;
 
-import static org.teiid.designer.vdb.Vdb.Event.MODEL_TRANSLATOR;
 import static org.teiid.designer.vdb.Vdb.Event.MODEL_JNDI_NAME;
 import static org.teiid.designer.vdb.Vdb.Event.MODEL_SOURCE_NAME;
+import static org.teiid.designer.vdb.Vdb.Event.MODEL_TRANSLATOR;
 
+import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.core.util.StringUtilities;
 
 /**
@@ -109,4 +110,24 @@ public class VdbSource {
 
         return text.toString();
 	}
+	
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals( Object object ) {
+        if (this == object) {
+            return true;
+        }
+
+        if ((object == null) || !getClass().equals(object.getClass())) {
+            return false;
+        }
+
+        VdbSource other = (VdbSource)object;
+        return this.vdb.equals(other.vdb) && CoreStringUtil.equals(this.name, other.name) && CoreStringUtil.equals(this.translatorName, other.translatorName) && CoreStringUtil.equals(this.jndiName, other.jndiName) ;
+    }
+	
 }

--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/SourceElement.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/SourceElement.java
@@ -14,7 +14,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
-import org.teiid.designer.vdb.VdbModelEntry;
 import org.teiid.designer.vdb.VdbSource;
 
 /**


### PR DESCRIPTION
- Resolves layout issue - bottom portion of multi-source table was not taking all available space.
- Resolve issue with VdbSourceInfo class.  Internally was storing the VdbSource objects in a HashMap keyed on source name.  The Map keys were getting out of sync with the objects when user changed source names.  Converted to use List instead of a Map
- Resolves problem with Delete and Add - if user was inline editing the translator or jndiName, the buttons did not do anything even though enabled.
