### PR TITLE
TEIIDDES-1971: Workaround for avoiding annoying errors in server log

### DIFF
--- a/plugins/org.teiid.designer.dqp/.options
+++ b/plugins/org.teiid.designer.dqp/.options
@@ -1,0 +1,17 @@
+# Master debug switch for plugin
+org.teiid.designer.dqp/debug = false
+
+# Option indicating if a trace message should be logged when a preview job is asked if it should run.
+org.teiid.designer.dqp/debug/preview/jobs/jobShouldRun = false
+
+# Option indicating if a trace message should be logged when a preview job is started.
+org.teiid.designer.dqp/debug/preview/jobs/jobStart = false
+
+# Option indicating if a trace message should be logged when a preview job is finished running.
+org.teiid.designer.dqp/debug/preview/jobs/jobDone = false
+
+# Option indicating if a trace message should be logged for how long a preview job took to run.
+org.teiid.designer.dqp/debug/preview/jobs/jobDuration = false
+
+# Option indicating if a trace message should be logged for the jboss host connection check 
+org.teiid.designer.dqp/debug/jboss/connection = false

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/DebugConstants.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/DebugConstants.java
@@ -52,4 +52,8 @@ public interface DebugConstants {
      */
     String PREVIEW_JOB_DURATION = PREVIEW_JOBS + "/jobDuration"; //$NON-NLS-1$
 
+    /**
+     *  Option indicating if a trace message should be logged for the jboss host connection check 
+     */
+    String JBOSS_CONNECTION = DEBUG + "/jboss/connection"; //$NON-NLS-1$
 }

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/i18n.properties
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/i18n.properties
@@ -136,6 +136,8 @@ jdbcInfoType = JDBC
 # TeiidServerAdapterUtil
 jbossServerNotStartedMessage = No Teiid Instance found (server not started)
 jbossServerConnectionFailureMessage = Failed to connect to the jboss server at {0}
+jbossServerConnectionStreamEmpty = The Jboss Server on {0}\:{1} returned an empty stream
+jbossServerHeartBeat = A Jboss Server on {0}\:{1} correctly answered a host-available request with "{2}"
 
 # OrphanedTeiidServerException
 OrphanedTeiidServerException.message = The Teiid Instance {0} does not have a parent jboss server


### PR DESCRIPTION
- "Connection reset by peer" messages appear in the jboss log due to making
  a socket connection from the host heatbeat requests but never using the
  socket. Almost like the server is upset that we connected then closed!!
- The read socket stream normally returns the hostname of the server so
  this is logged along with a nice message, ensuring the socket is used
  before closing it.
