### PR TITLE
TEIIDDES-2008 Disallow ModeShape import in Teiid Connection Importer, add JDBC warning message

### DIFF
--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/Messages.java
@@ -87,6 +87,9 @@ public class Messages extends NLS {
     public static String selectDataSourcePage_dataSourcePropertiesGroupText;
     public static String selectDataSourcePage_NoSourceSelectedMsg;
     public static String selectDataSourcePage_CannotImportSourceTypeMsg;
+    public static String selectDataSourcePage_CannotImportModeshapeTypeMsg;
+    public static String selectDataSourcePage_CannotImportLdapTypeMsg;
+    public static String selectDataSourcePage_ConsiderJDBCImporterForSourceTypeMsg;
     
     public static String SelectTranslatorPage_title;
     public static String SelectTranslatorPage_dsNameLabel;

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
@@ -78,6 +78,9 @@ selectDataSourcePage_dataSourceGroupText=Data Sources
 selectDataSourcePage_dataSourcePropertiesGroupText=Data Source Properties
 selectDataSourcePage_NoSourceSelectedMsg=Please select a DataSource from the available list
 selectDataSourcePage_CannotImportSourceTypeMsg=Sources of type "{0}" cannot be imported with this wizard.  Please consult the Teiid documentation for manual modeling instructions. 
+selectDataSourcePage_CannotImportModeshapeTypeMsg=Sources of type "{0}" cannot be imported with this wizard.  Please use the JDBC Importer for ModeShape imports.
+selectDataSourcePage_CannotImportLdapTypeMsg=Sources of type "{0}" cannot be imported with this wizard.  Please use the LDAP Importer.
+selectDataSourcePage_ConsiderJDBCImporterForSourceTypeMsg=If the selected source is of type JDBC it is recommended to use the JDBC Importer, if possible. \n If you proceed, please consult the teiid docs for optional source import properties.
 
 SelectTranslatorPage_title=Select the translator and target model for the import
 SelectTranslatorPage_dsNameLabel=DataSource:

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/SelectDataSourcePage.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/SelectDataSourcePage.java
@@ -45,6 +45,23 @@ public class SelectDataSourcePage extends AbstractWizardPage
     	DISALLOWED_SOURCES = new ArrayList<String>();
     	DISALLOWED_SOURCES.add("ldap");  //$NON-NLS-1$
     	DISALLOWED_SOURCES.add("mongodb"); //$NON-NLS-1$
+    	DISALLOWED_SOURCES.add("modeshape"); //$NON-NLS-1$
+    }
+    
+    // Built-in types
+    private static final List<String> BUILTIN_TYPES;
+    static {
+    	BUILTIN_TYPES = new ArrayList<String>();
+    	BUILTIN_TYPES.add("file");  //$NON-NLS-1$
+    	BUILTIN_TYPES.add("google"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("infinispan"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("ldap");  //$NON-NLS-1$
+    	BUILTIN_TYPES.add("modeshape"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("mongodb"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("salesforce");  //$NON-NLS-1$
+    	BUILTIN_TYPES.add("teiid"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("teiid-local"); //$NON-NLS-1$
+    	BUILTIN_TYPES.add("webservice"); //$NON-NLS-1$
     }
 
     private TeiidImportManager importManager;
@@ -160,8 +177,18 @@ public class SelectDataSourcePage extends AbstractWizardPage
         if(!CoreStringUtil.isEmpty(selectedDataSourceDriverName)) {
         	String driverNameLC = selectedDataSourceDriverName.toLowerCase();
         	if(DISALLOWED_SOURCES.contains(driverNameLC)) {  
-                setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_CannotImportSourceTypeMsg, driverNameLC) , ERROR);
+        		if(driverNameLC.equals("modeshape")) {  //$NON-NLS-1$
+        			setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_CannotImportModeshapeTypeMsg, driverNameLC) , ERROR);
+        		} else if(driverNameLC.equals("ldap")) { //$NON-NLS-1$
+        			setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_CannotImportLdapTypeMsg, driverNameLC) , ERROR);
+        		}  else {
+        			setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_CannotImportSourceTypeMsg, driverNameLC) , ERROR);
+        		}
                 return false;        		
+        	}
+        	if(!BUILTIN_TYPES.contains(driverNameLC)) {
+    			setThisPageComplete( NLS.bind(Messages.selectDataSourcePage_ConsiderJDBCImporterForSourceTypeMsg, driverNameLC) , WARNING);
+    			return true;
         	}
         }
         setThisPageComplete(EMPTY_STR, NONE);


### PR DESCRIPTION
- Prevent Teiid Connection Import for ModeShape.  Message informing to use JDBC importer.
- Add warning message for JDBC imports, suggesting use of JDBC importer instead.
