### PR TITLE
TEIIDDES-2013 Preview with SalesForce data source does not work

### DIFF
--- a/plugins/org.teiid.designer.modelgenerator.salesforce/src/org/teiid/designer/modelgenerator/salesforce/util/SalesForceConnectionInfoProvider.java
+++ b/plugins/org.teiid.designer.modelgenerator.salesforce/src/org/teiid/designer/modelgenerator/salesforce/util/SalesForceConnectionInfoProvider.java
@@ -25,7 +25,7 @@ import org.teiid.designer.type.IDataTypeManagerService.DataSourceTypes;
  */
 public class SalesForceConnectionInfoProvider extends ConnectionInfoHelper implements IConnectionInfoProvider {
 
-    public final static String SALESFORCE_DATASOURCE_URL = "url"; //$NON-NLS-1$
+    public final static String SALESFORCE_DATASOURCE_URL = "URL"; //$NON-NLS-1$
     public final static String SALESFORCE_DATASOURCE_USERNAME = "username"; //$NON-NLS-1$
     public final static String SALESFORCE_DATASOURCE_PASSWORD = "password"; //$NON-NLS-1$
     public final static String SALESFORCE_TRANSLATOR_NAME = "salesforce"; //$NON-NLS-1$


### PR DESCRIPTION
- Resolves issue in designer, if user supplies the salesforce Url in the SF connection profile rather than take the default.  Teiid requires the URL property to be uppercase.  
