### PR TITLE
TEIIDDES-2064: Update the teiid version upon successful connection

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/i18n.properties
@@ -709,6 +709,7 @@ TeiidServerOverviewSection.description=The configuration of the Teiid Instance i
 TeiidServerOverviewSection.customLabel=Display Name
 TeiidServerOverviewSection.hostLabel=Host
 TeiidServerOverviewSection.versionLabel=Teiid Runtime Version
+TeiidServerOverviewSection.versionValueTooltip=The runtime version is acquired from the running Teiid instance. If the Teiid instance is stopped then the version can be modified manually but care should be taken since this will influence the runtime client used to connect to the instance when started. 
 TeiidServerOverviewSection.jbLabel=JBoss Server
 TeiidServerOverviewSection.newHyperlinkLabel=New
 TeiidServerOverviewSection.editHyperlinkLabel=Edit

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/JBossServerUtil.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/JBossServerUtil.java
@@ -15,6 +15,8 @@ import org.eclipse.wst.server.core.IServer;
 import org.jboss.ide.eclipse.as.core.server.internal.JBossServer;
 import org.teiid.designer.runtime.DebugConstants;
 import org.teiid.designer.runtime.DqpPlugin;
+import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
+import org.teiid.designer.runtime.version.spi.TeiidServerVersion;
 
 /**
  *
@@ -116,5 +118,16 @@ public class JBossServerUtil {
             return false;
 
         return true;
+    }
+
+    /**
+     * @param parentServer
+     * @param jbossServer
+     *
+     * @return since the jboss server is the older version 5, it cannot be queried
+     *                 and can only be a maximum of version 7
+     */
+    public static ITeiidServerVersion getTeiidRuntimeVersion(IServer parentServer, JBossServer jbossServer) {
+        return TeiidServerVersion.DEFAULT_TEIID_7_SERVER;
     }
 }

--- a/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/TeiidServerAdapterFactory.java
+++ b/plugins/org.teiid.designer.dqp/src/org/teiid/designer/runtime/adapter/TeiidServerAdapterFactory.java
@@ -23,7 +23,7 @@ import org.teiid.designer.runtime.spi.ITeiidAdminInfo;
 import org.teiid.designer.runtime.spi.ITeiidJdbcInfo;
 import org.teiid.designer.runtime.spi.ITeiidServer;
 import org.teiid.designer.runtime.spi.ITeiidServerManager;
-import org.teiid.designer.runtime.version.spi.TeiidServerVersion;
+import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 
 /**
  * Adapter factory that can adapt an {@link IServer} to a {@link ITeiidServer}
@@ -247,7 +247,7 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
         optionList.add(ServerOptions.ADMIN_SECURE_CONNECTION);
         
         TeiidServerFactory factory = new TeiidServerFactory();
-        ITeiidServer teiidServer = factory.createTeiidServer(TeiidServerVersion.DEFAULT_TEIID_7_SERVER,
+        ITeiidServer teiidServer = factory.createTeiidServer(JBossServerUtil.getTeiidRuntimeVersion(parentServer, jbossServer),
                                                                                         getTeiidServerManager(),
                                                                                         parentServer, 
                                                                                         ITeiidAdminInfo.DEFAULT_LEGACY_PORT, 
@@ -281,5 +281,26 @@ public class TeiidServerAdapterFactory implements IAdapterFactory {
         }
         
         return false;
+    }
+
+    /**
+     * @param server
+     *
+     * @return the teiid runtime version of the given server
+     * @throws Exception
+     */
+    public ITeiidServerVersion getTeiidRuntimeVersion(IServer server) throws Exception {
+        if (! getTeiidServerManager().isStarted())
+            return null;
+
+        JBoss7Server jb7 = (JBoss7Server) server.loadAdapter(JBoss7Server.class, null);
+        if (jb7 != null) {
+            return JBoss7ServerUtil.getTeiidRuntimeVersion(server, jb7);
+        } else {
+            JBossServer jb = (JBossServer) server.loadAdapter(JBossServer.class, null);
+            if (jb != null)
+                return JBossServerUtil.getTeiidRuntimeVersion(server, jb);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
- TeiidServer
  - Once the instance has successfully connected update its version with
    the runtime version from the server. If the instance is the default then
    this value will be displayed and used accordingly.
- TeiidServerEditor
  - Make the runtime version editable if the instance is stopped. This will
    allow the user to control the version of the instance, including which
    runtime client is used to connect to it.
  - Once the instance is successfully started, the runtime version is
    discovered and the editor's version is populated correctly and no longer
    editable.
