### PR TITLE
TEIIDDES-2078 changed logic to return FALSE if hasProcedure() catches

### DIFF
--- a/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/metadata/TransformationMetadata.java
+++ b/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/metadata/TransformationMetadata.java
@@ -258,7 +258,7 @@ public abstract class TransformationMetadata implements IQueryMetadataInterface 
         try {
             return getStoredProcInfoDirect(name) != null;
         } catch (Exception e) {
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
exception.
- This is because the behavior of the underlying metadata call is
  different for this class than the client TransformationMetadata classes.
