### PR TITLE
TEIIDDES-2101 Query resolution fails on procedure that references XmlDocument

### DIFF
--- a/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/metadata/TransformationMetadata.java
+++ b/plugins/org.teiid.designer.transformation/src/org/teiid/designer/transformation/metadata/TransformationMetadata.java
@@ -839,6 +839,7 @@ public abstract class TransformationMetadata implements IQueryMetadataInterface 
                 IQueryService queryService = ModelerCore.getTeiidQueryService();
                 IMappingDocumentFactory factory = queryService.getMappingDocumentFactory();
                 mappingDoc = factory.loadMappingDocument(inputStream, groupName);
+                return mappingDoc;
             } catch (Exception e) {
                 throw new TeiidDesignerException(
                                                       e,


### PR DESCRIPTION
- getMappingNode was always returning null
