### PR TITLE
TEIIDDES-2111: Fixes NPE when choosing Teiid Driver

### DIFF
--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/version/spi/TeiidServerVersion.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/version/spi/TeiidServerVersion.java
@@ -263,7 +263,7 @@ public class TeiidServerVersion implements ITeiidServerVersion {
     
     @Override
     public boolean hasWildCards() {
-        return minorVersion.equals(WILDCARD) || microVersion.equals(WILDCARD);
+        return majorVersion.equals(WILDCARD) || minorVersion.equals(WILDCARD) || microVersion.equals(WILDCARD);
     }
 
     @Override
@@ -296,7 +296,9 @@ public class TeiidServerVersion implements ITeiidServerVersion {
 
     @Override
     public boolean compareTo(ITeiidServerVersion otherVersion) {
-        if (! getMajor().equals(otherVersion.getMajor()))
+        String entryMajor = otherVersion.getMajor();
+
+        if (! getMajor().equals(entryMajor) && ! getMajor().equals(WILDCARD) && ! entryMajor.equals(WILDCARD))
             return false;
         
         String entryMinor = otherVersion.getMinor();
@@ -326,7 +328,7 @@ public class TeiidServerVersion implements ITeiidServerVersion {
         if (! this.hasWildCards())
             return this;
 
-        String major = getMajor();
+        String major = getMajor().equals(WILDCARD) ? SEVEN : getMajor();
         String minor = getMinor().equals(WILDCARD) ? ZERO : getMinor();
         String micro = getMicro().equals(WILDCARD) ? ZERO : getMicro();
 
@@ -338,7 +340,7 @@ public class TeiidServerVersion implements ITeiidServerVersion {
         if (! this.hasWildCards())
             return this;
 
-        String major = getMajor();
+        String major = getMajor().equals(WILDCARD) ? NINE : getMajor();
         String minor = getMinor().equals(WILDCARD) ? NINE : getMinor();
         String micro = getMicro().equals(WILDCARD) ? NINE : getMicro();
 
@@ -347,21 +349,18 @@ public class TeiidServerVersion implements ITeiidServerVersion {
 
     @Override
     public boolean isGreaterThan(ITeiidServerVersion otherVersion) {
-        int majCompResult = getMajor().compareTo(otherVersion.getMajor());
+        ITeiidServerVersion myMaxVersion = getMaximumVersion();
+        ITeiidServerVersion otherMinVersion = otherVersion.getMinimumVersion();
+
+        int majCompResult = myMaxVersion.getMajor().compareTo(otherMinVersion.getMajor());
         if (majCompResult > 0)
             return true;
-
-        if (getMinor().equals(WILDCARD) || otherVersion.getMinor().equals(WILDCARD))
-            return false;
         
-        int minCompResult = getMinor().compareTo(otherVersion.getMinor());
+        int minCompResult = myMaxVersion.getMinor().compareTo(otherMinVersion.getMinor());
         if (majCompResult == 0 && minCompResult > 0)
             return true;
 
-        if (getMicro().equals(WILDCARD) || otherVersion.getMicro().equals(WILDCARD))
-            return false;
-
-        int micCompResult = getMicro().compareTo(otherVersion.getMicro());
+        int micCompResult = myMaxVersion.getMicro().compareTo(otherMinVersion.getMicro());
         if (majCompResult == 0 && minCompResult == 0 && micCompResult > 0)
             return true;
             
@@ -370,21 +369,18 @@ public class TeiidServerVersion implements ITeiidServerVersion {
 
     @Override
     public boolean isLessThan(ITeiidServerVersion otherVersion) {
-        int majCompResult = getMajor().compareTo(otherVersion.getMajor());
+        ITeiidServerVersion myMaxVersion = getMaximumVersion();
+        ITeiidServerVersion otherMinVersion = otherVersion.getMinimumVersion();
+
+        int majCompResult = myMaxVersion.getMajor().compareTo(otherMinVersion.getMajor());
         if (majCompResult < 0)
             return true;
 
-        if (getMinor().equals(WILDCARD) || otherVersion.getMinor().equals(WILDCARD))
-            return false;
-        
-        int minCompResult = getMinor().compareTo(otherVersion.getMinor());
+        int minCompResult = myMaxVersion.getMinor().compareTo(otherMinVersion.getMinor());
         if (majCompResult == 0 && minCompResult < 0)
             return true;
 
-        if (getMicro().equals(WILDCARD) || otherVersion.getMicro().equals(WILDCARD))
-            return false;
-
-        int micCompResult = getMicro().compareTo(otherVersion.getMicro());
+        int micCompResult = myMaxVersion.getMicro().compareTo(otherMinVersion.getMicro());
         if (majCompResult == 0 && minCompResult == 0 && micCompResult < 0)
             return true;
             

--- a/plugins/teiid/org.teiid.runtime.client/plugin.xml
+++ b/plugins/teiid/org.teiid.runtime.client/plugin.xml
@@ -94,7 +94,7 @@
                     generated="false"
                     id="org.eclipse.datatools.connectivity.db.version"
                     name="%VERSION_PROPERTY_NAME"
-                    value="7.7.+"
+                    value="x.x.x"
                     required="true"
                     visible="false"/>
                 <property
@@ -126,11 +126,11 @@
        point="org.eclipse.datatools.connectivity.sqm.core.databaseDefinition">
       <definition
           allowsConnections="true"
-          description="Definition of the Teiid Database 8.4"
+          description="Definition of the Teiid Database"
           file="src/org/teiid/runtime/client/database/teiidDB.xmi"
           product="Teiid"
           productDisplayString="%PRODUCT_DISPLAY_STRING"
-          version="7.7+"
+          version="x.x.x"
           versionDisplayString="%VERSION_DISPLAY_STRING">
       </definition>
    </extension>
@@ -141,7 +141,7 @@
             provider="org.teiid.datatools.connectivity.sql.TeiidSchemaLoader"
             eclass="org.eclipse.datatools.modelbase.sql.schema.Schema"
             product="Teiid"
-            version="7.7+"/>
+            version="x.x.x"/>
    </extension>
    <extension point="org.eclipse.datatools.connectivity.ui.driverUIContributor">
       <driverUIContributor
@@ -166,7 +166,7 @@
             configurationClass="org.teiid.datatools.connectivity.ui.TeiidDBUIConfiguration"
             default="false"
             product="Teiid"
-            version="7.7+">
+            version="x.x.x">
       </dbUIConfiguration>
    </extension>
 

--- a/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/admin/ExecutionAdmin.java
+++ b/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/admin/ExecutionAdmin.java
@@ -740,8 +740,9 @@ public class ExecutionAdmin implements IExecutionAdmin {
 
     @Override
     public void undeployVdb( String vdbName) throws Exception {
-        adminSpec.undeploy(admin, appendVdbExtension(vdbName), getVdb(vdbName).getVersion());
         ITeiidVdb vdb = getVdb(vdbName);
+        adminSpec.undeploy(admin, appendVdbExtension(vdbName), vdb != null ? vdb.getVersion() : 1);
+        vdb = getVdb(vdbName);
 
         refreshVDBs();
 


### PR DESCRIPTION
- TeiidServerVersion
  - Allow major component to be a wildcard
  - Fixes isGreaterThan and isLessThan to allow for wildcards by using
    getMinimum and getMaximum
- ConnecitivityUtil
  - Simplifies by extracting duplicate code
  - Tries to ensure a valid driver id by either getting it from the Driver
    Manager or returning it from the creation of the adhoc driver
- plugin.xml
  - The version of the teiid runtime client driver should be universal
    since its capable of being used with any version of teiid. Thus, changes
    version to the all wildcard x.x.x
- ExecutionAdmin
  - Check for whether the vdb existed or not and if not just give a version
    of 1. Version only relevant for backward compatibility with teiid 7
