### PR TITLE
improves teiid connection importer support for resource adapters

### DIFF
--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/messages.properties
@@ -38,7 +38,7 @@ dataSourcePropertiesPanel_invalidPropertyMsg=One or more property has an invalid
 dataSourcePropertiesPanel_validPropertyTooltip=The value for {0}
 dataSourcePropertiesPanel_invalidPropertyTooltip=Enter a valid value for {0}
 dataSourcePropertiesPanelOk=Data Source Properties OK
-dataSourcePropertiesPanel_requiredLabel=* - required property
+dataSourcePropertiesPanel_requiredLabel=* - denotes required property
 
 dataSourcePanel_newButtonText=New...
 dataSourcePanel_deleteButtonText=Delete

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/CreateDataSourcePanel.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/CreateDataSourcePanel.java
@@ -299,7 +299,7 @@ public final class CreateDataSourcePanel extends Composite implements UiConstant
         if(isCreateNew) {
             return this.driversPanel.getSelectedDriverName();
         }
-        return this.dataSourceManager.getDataSourceDriver(this.editDSName);
+        return this.dataSourceManager.getDataSourceDriver(this.editDSName,null);
     }
     
     /**

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePanel.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePanel.java
@@ -10,6 +10,7 @@ package org.teiid.designer.teiidimporter.ui.panels;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -465,6 +466,10 @@ public final class DataSourcePanel extends Composite implements UiConstants {
             dataSources = new ArrayList<ITeiidDataSource>();
             UTIL.log(ex);
         }
+        
+        // get className - driverMap for RA sources
+        Map<String,String> classNameDriverNameMap = dataSourceManager.getClassNameDriverNameMap(dataSources);
+        
         for(ITeiidDataSource dataSource: dataSources) {
             DataSourceItem dsObj = new DataSourceItem();
             // ------------------------
@@ -483,7 +488,7 @@ public final class DataSourcePanel extends Composite implements UiConstants {
             }
 
             // Driver name
-            String dsDriver = dataSourceManager.getDataSourceDriver(name);
+            String dsDriver = dataSourceManager.getDataSourceDriver(name, classNameDriverNameMap);
             dsObj.setDriver(dsDriver);
             // ------------------------
             // Add PropertyItem to List

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePropertiesPanel.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/DataSourcePropertiesPanel.java
@@ -32,9 +32,11 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.ISharedImages;
 import org.teiid.core.designer.util.CoreArgCheck;
 import org.teiid.core.designer.util.CoreStringUtil;
@@ -66,6 +68,7 @@ public final class DataSourcePropertiesPanel extends Composite implements UiCons
     
     private List<DataSourcePropertiesPanelListener> listeners = new ArrayList<DataSourcePropertiesPanelListener>();
     private Button resetButton;
+    private Text propDescriptionText;
     
     /**
      * DataSourcePropertiesPanel constructor
@@ -136,6 +139,15 @@ public final class DataSourcePropertiesPanel extends Composite implements UiCons
         // Create 'Required' label below table 
         Label reqdLabel = new Label(panel,SWT.NONE);
         reqdLabel.setText(Messages.dataSourcePropertiesPanel_requiredLabel);
+
+        // Create Property description label below table 
+        propDescriptionText = new Text(panel, SWT.MULTI | SWT.WRAP | SWT.READ_ONLY | SWT.V_SCROLL);
+        propDescriptionText.setBackground(parent.getBackground());
+        propDescriptionText.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_BLUE));
+        GridData descriptionLabelGridData = new GridData(GridData.FILL_HORIZONTAL);
+        descriptionLabelGridData.horizontalIndent = 20;
+        descriptionLabelGridData.heightHint = (2 * propDescriptionText.getLineHeight());
+        propDescriptionText.setLayoutData(descriptionLabelGridData);
 
         ColumnViewerToolTipSupport.enableFor(this.propertiesViewer);
         this.propertiesViewer.setContentProvider(new IStructuredContentProvider() {
@@ -496,8 +508,10 @@ public final class DataSourcePropertiesPanel extends Composite implements UiCons
      * Handler for selection changed events
      */
     void handlePropertySelected( SelectionChangedEvent event ) {
-        if(isReadOnly) return;
         IStructuredSelection selection = (IStructuredSelection)event.getSelection();
+        setPropertyDescriptionText(selection);
+
+        if(isReadOnly) return;
 
         if (selection.isEmpty()) {
             if (this.resetButton.isEnabled()) {
@@ -511,7 +525,20 @@ public final class DataSourcePropertiesPanel extends Composite implements UiCons
             }
         }
     }
-
+    
+   /*
+    * Sets the property description text below the table
+    * @selection the selection
+    */
+    private void setPropertyDescriptionText(IStructuredSelection selection) {
+        if(selection==null || selection.isEmpty()) {
+        	this.propDescriptionText.setText(""); //$NON-NLS-1$
+        } else {
+            PropertyItem prop = (PropertyItem)selection.getFirstElement();
+            this.propDescriptionText.setText(prop.getDescription());
+        }
+    }
+    
     /*
      * Handler for ResetAction
      */

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/TranslatorHelper.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/panels/TranslatorHelper.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.Properties;
 import org.eclipse.datatools.connectivity.IConnectionProfile;
 import org.teiid.core.designer.util.CoreArgCheck;
-import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 import org.teiid.designer.teiidimporter.ui.UiConstants;
 import org.teiid.designer.ui.common.UiConstants.ConnectionProfileIds;
@@ -45,13 +44,13 @@ public class TranslatorHelper implements UiConstants {
     public static final String TEIID_SALESORCE_DRIVER_DISPLAYNAME = "Salesforce"; //$NON-NLS-1$
     public static final String TEIID_WEBSERVICE_DRIVER_DISPLAYNAME = "WebService"; //$NON-NLS-1$
 
-    public static final String TEIID_FILE_CLASS = "org.teiid.resource.adapter.file.FileManagedConnectionFactory"; //$NON-NLS-1$
     public static final String TEIID_GOOGLE_CLASS = "org.teiid.resource.adapter.google.SpreadsheetManagedConnectionFactory"; //$NON-NLS-1$
-    public static final String TEIID_INFINISPAN_CLASS = "org.teiid.resource.adapter.infinispan.InfinispanManagedConnectionFactory"; //$NON-NLS-1$
-    public static final String TEIID_LDAP_CLASS = "org.teiid.resource.adapter.ldap.LDAPManagedConnectionFactory"; //$NON-NLS-1$
-    public static final String TEIID_SALESORCE_CLASS = "org.teiid.resource.adapter.salesforce.SalesForceManagedConnectionFactory"; //$NON-NLS-1$
-    public static final String TEIID_WEBSERVICE_CLASS = "org.teiid.resource.adapter.ws.WSManagedConnectionFactory"; //$NON-NLS-1$
-    public static final String TEIID_MONGODB_CLASS = "org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_FILE_CLASS = "org.teiid.resource.adapter.file.FileManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_INFINISPAN_CLASS = "org.teiid.resource.adapter.infinispan.InfinispanManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_LDAP_CLASS = "org.teiid.resource.adapter.ldap.LDAPManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_SALESORCE_CLASS = "org.teiid.resource.adapter.salesforce.SalesForceManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_WEBSERVICE_CLASS = "org.teiid.resource.adapter.ws.WSManagedConnectionFactory"; //$NON-NLS-1$
+//    public static final String TEIID_MONGODB_CLASS = "org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory"; //$NON-NLS-1$
     
     public static final String ACCESS = "access"; //$NON-NLS-1$
     public static final String DB2 = "db2"; //$NON-NLS-1$
@@ -216,52 +215,6 @@ public class TranslatorHelper implements UiConstants {
         }
 
         return JDBC_ANSI; 
-	}
-	
-	/**
-	 * Get the Driver Name for the supplied class and server version
-	 * @param driverClassName the driver class name
-	 * @param teiidVersion the teiid version
-	 * @return the driver name
-	 */
-	public static String getDriverNameForClass(String driverClassName, ITeiidServerVersion teiidVersion) {
-		String driverName = null;
-		if(!CoreStringUtil.isEmpty(driverClassName)) {
-			// Teiid 8.3 and below
-			if(!isTeiid84OrHigher(teiidVersion)) {
-				if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_FILE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_FILE_DRIVER;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_GOOGLE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_GOOGLE_DRIVER;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_INFINISPAN_CLASS)) {
-					driverName = TranslatorHelper.TEIID_INFINISPAN_DRIVER;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_LDAP_CLASS)) {
-					driverName = TranslatorHelper.TEIID_LDAP_DRIVER;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_SALESORCE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_SALESORCE_DRIVER;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_WEBSERVICE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_WEBSERVICE_DRIVER;
-				}
-			// Teiid 8.4 and higher
-			} else {
-				if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_FILE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_FILE_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_GOOGLE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_GOOGLE_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_INFINISPAN_CLASS)) {
-					driverName = TranslatorHelper.TEIID_INFINISPAN_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_LDAP_CLASS)) {
-					driverName = TranslatorHelper.TEIID_LDAP_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_SALESORCE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_SALESORCE_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_WEBSERVICE_CLASS)) {
-					driverName = TranslatorHelper.TEIID_WEBSERVICE_DRIVER_84UP;
-				} else if(driverClassName.equalsIgnoreCase(TranslatorHelper.TEIID_MONGODB_CLASS)) {
-					driverName = TranslatorHelper.TEIID_MONGODB_DRIVER_84UP;
-				}
-			}
-		}
-		return driverName;
 	}
 	
 	/**


### PR DESCRIPTION
- if 'driver-name' property is found it is used to get DataSource driver
- if not found, the available ds templates are iterated to find 'managedconnectionfactory-class' default that matches the datasource 'class-name'
- included description at bottom of property table - displayed upon selection
