### PR TITLE
Resolves issue with Teiid Connection import on windows

### DIFF
--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/TeiidImportManager.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/TeiidImportManager.java
@@ -476,7 +476,7 @@ public class TeiidImportManager implements ITeiidImportServer, UiConstants {
     public void setTargetModelLocation(IPath targetPath) {
         this.targetModelLocation=targetPath;
         if(this.ddlImporter!=null) {
-            this.ddlImporter.setModelFolder(targetPath.toOSString());
+            this.ddlImporter.setModelFolder(targetPath.toString());
         }
     }
     


### PR DESCRIPTION
- adopts same method for getting the container path as DdlImporter, which does work on windows os
