### PR TITLE
TEIIDDES-2145 Edit Translator Override Properties Dialog - limit properties table height

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/properties/EditTOPropertiesDialog.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/properties/EditTOPropertiesDialog.java
@@ -4,6 +4,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -61,6 +62,7 @@ public class EditTOPropertiesDialog extends TitleAreaDialog {
         
         Composite mainPanel = new Composite(parent, SWT.NONE);
         GridLayoutFactory.fillDefaults().margins(20, 20).applyTo(mainPanel);
+        GridDataFactory.fillDefaults().grab(true, true).applyTo(mainPanel);
 
         this.setTitle(DqpUiConstants.UTIL.getString("EditTOPropertiesDialog.title")); //$NON-NLS-1$
         this.setMessage(DqpUiConstants.UTIL.getString("EditTOPropertiesDialog.message")); //$NON-NLS-1$

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/properties/EditTOPropertiesPanel.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/connection/properties/EditTOPropertiesPanel.java
@@ -111,12 +111,14 @@ public class EditTOPropertiesPanel {
                 }
             });
 
+            int visibleTableRows = 7;
             Table table = this.propertiesViewer.getTable();
             table.setHeaderVisible(true);
             table.setLinesVisible(true);
             table.setLayout(new TableLayout());
             table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
             ((GridData)table.getLayoutData()).horizontalSpan = 2;
+            ((GridData)table.getLayoutData()).heightHint = table.getItemHeight() * visibleTableRows;
 
             // create columns
             TableViewerColumn column = new TableViewerColumn(this.propertiesViewer, SWT.LEFT);


### PR DESCRIPTION
- set properties table visible rows to 7.  prevents table from getting huge.
- main panel now grabs excess space - better resizing of the dialog.
