### PR TITLE
TEIIDDES-2120: Move Xsd files from models to other files section of vdb

### DIFF
--- a/plugins/org.teiid.core.designer/src/org/teiid/core/designer/util/StringConstants.java
+++ b/plugins/org.teiid.core.designer/src/org/teiid/core/designer/util/StringConstants.java
@@ -23,7 +23,12 @@ public interface StringConstants {
      * A space.
      */
     String SPACE = " "; //$NON-NLS-1$
-    
+
+    /**
+     * A star.
+     */
+    String STAR = "*"; //$NON-NLS-1$
+
     /**
      * An underscore.
      */
@@ -64,5 +69,10 @@ public interface StringConstants {
      * The String that should be used to separate lines; defaults to {@link #NEW_LINE}
      */
     String LINE_SEPARATOR = System.getProperty(LINE_SEPARATOR_PROPERTY_NAME, NEW_LINE);
+
+    /**
+     * Forward slash
+     */
+    String FORWARD_SLASH = "/"; //$NON-NLS-1$
 
 }

--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/util/VdbHelper.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/util/VdbHelper.java
@@ -10,6 +10,7 @@ package org.teiid.designer.core.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -18,16 +19,125 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.teiid.core.designer.util.StringConstants;
 import org.teiid.designer.core.ModelerCore;
 
 /**
  *  Methods for selecting Vdb Files (udf jars or other) from the fileSystem or workspace
  */
-public class VdbHelper {
-    
-    public static final String UDF_FOLDER = "lib";  //$NON-NLS-1$
-    public static final String OTHER_FILES_FOLDER = "otherFiles";  //$NON-NLS-1$
+public class VdbHelper implements StringConstants {
+
+    /**
+     * File filter for use with dialog file choosers
+     */
+    public static class FileFilter {
+
+        private String name;
+
+        private String filter;
+
+        /**
+         * @param name
+         * @param filter
+         */
+        public FileFilter(String name, String filter) {
+            this.name = name;
+            this.filter = filter;
+        }
+
+        /**
+         * @return the name
+         */
+        public String getName() {
+            return this.name;
+        }
+
+        /**
+         * @return the filter
+         */
+        public String getFilter() {
+            return this.filter;
+        }
+    }
+
+    /**
+     * Jar file extension
+     */
     public static final String JAR_EXT = "jar";  //$NON-NLS-1$
+
+    /**
+     * File filter for choosing only jar files
+     */
+    public static final FileFilter JAR_FILE_FILTER = new FileFilter(JAR_EXT, STAR + DOT + JAR_EXT);
+
+    /**
+     * File filter that shows all files
+     */
+    public static final FileFilter ALL_FILE_FILTER = new FileFilter("All files", STAR + DOT + STAR); //$NON-NLS-1$
+
+    /**
+     * Folder locations used by files populated
+     * in vdbs
+     */
+    public enum VdbFolders {
+        /**
+         * Location of project udf files
+         */
+        UDF("lib", "lib", JAR_FILE_FILTER, JAR_EXT),  //$NON-NLS-1$ //$NON-NLS-2$
+
+        /**
+         * Location of other project files
+         */
+        OTHER_FILES(DOT, "otherFiles", ALL_FILE_FILTER, null); //$NON-NLS-1$
+
+        private String readFolder;
+
+        private String writeFolder;
+
+        private FileFilter fileFilter;
+
+        private String extension;
+
+        private VdbFolders(String readFolder, String writeFolder, FileFilter fileFilter, String extension) {
+            this.readFolder = readFolder;
+            this.writeFolder = writeFolder;
+            this.fileFilter = fileFilter;
+            this.extension = extension;
+        }
+
+        /**
+         * @return folder that should be read from
+         */
+        public String getReadFolder() {
+            return readFolder;
+        }
+
+        /**
+         * @return folder that should write to
+         */
+        public String getWriteFolder() {
+            return writeFolder;
+        }
+
+        @Override
+        public String toString() {
+            return readFolder;
+        }
+
+        /**
+         * @return file filter associated with this vdb folder
+         */
+        public FileFilter getFileFilter() {
+            return fileFilter;
+        }
+
+        /**
+         * @return associated extension
+         */
+        public String getExtension() {
+            return extension;
+        }
+    }
 
     /**
      * Get all of the Udf jar resources for the supplied project
@@ -38,7 +148,7 @@ public class VdbHelper {
         List<IResource> jarResources = new ArrayList<IResource>();
         
         // Get Udf jar folder
-        IFolder jarFolder = getFolder(project,UDF_FOLDER);
+        IContainer jarFolder = getFolder(project, VdbFolders.UDF.getReadFolder());
         
         // Iterate the child resources, looking for lib folder
         if(jarFolder!=null) {
@@ -59,30 +169,36 @@ public class VdbHelper {
 
     /**
      * Get the project's folder that either contains the Udf jars or other files.  If it doesnt exist, returns null.
+     *
      * @param project the supplied project
      * @param folderName the name of the folder to get
      * @return the folder within the project, null if non-existent.
      */
-    public static IFolder getFolder(IProject project, String folderName) {
+    public static IContainer getFolder(IProject project, String folderName) {
+        if (folderName == null || DOT.equals(folderName))
+            return project;
+
         IFolder libFolder = null;
-        if(project!=null) {
+        if (project != null) {
             IResource[] resources = null;
             try {
                 resources = project.members();
             } catch (CoreException ex) {
                 return null;
             }
-            // Iterate the child resources, looking for lib folder
-            if(resources!=null) {
-                for(int i=0; i<resources.length; i++) {
+
+            // Iterate the child resources, looking for folder
+            if (resources != null) {
+                for (int i = 0; i < resources.length; i++) {
                     IResource theResc = resources[i];
-                    if(theResc instanceof IFolder && ((IFolder)theResc).getName().equalsIgnoreCase(folderName)) { 
+                    if (theResc instanceof IFolder && folderName.equalsIgnoreCase(((IFolder)theResc).getName())) {
                         libFolder = (IFolder)theResc;
                         break;
                     }
                 }
             }
         }
+
         return libFolder;
     }
     
@@ -123,7 +239,7 @@ public class VdbHelper {
      * @param fileName the specified file short name
      * @return the file relative path in the project, null if not found
      */
-    public static String getFileRelativePath(IFolder folder,String fileName) {
+    public static String getFileRelativePath(IContainer folder,String fileName) {
         String relativePath = null;
         // Iterate the child resources, looking for jar
         if(folder!=null) {
@@ -149,7 +265,7 @@ public class VdbHelper {
      * @param fileName the name of the file to find
      * @return 'true' if found, 'false' if not.
      */
-    public static boolean isFileInFolder(IFolder folder,String fileName) {
+    public static boolean isFileInFolder(IContainer folder, String fileName) {
         boolean found = false;
         // Iterate the child resources, looking for lib folder
         if(folder!=null) {
@@ -172,10 +288,10 @@ public class VdbHelper {
     /**
      * Determine if the supplied folder contains at least one jar file
      * @param folder the supplied folder
-     * @param udfJar 'true' if looking for only jars, 'false' otherwise
+     * @param extension of files contained in folder or null for any type of file
      * @return 'true' if the folder contains at least one file, 'false' if not.
      */
-    public static boolean folderContainsOneOrMoreFile(IFolder folder, boolean udfJar) {
+    public static boolean folderContainsOneOrMoreFile(IContainer folder, String extension) {
         boolean contains = false;
         // Iterate the child resources, looking for lib folder
         if(folder!=null) {
@@ -183,14 +299,16 @@ public class VdbHelper {
                 IResource[] folderEntries = folder.members();
                 for(int j=0; j<folderEntries.length; j++) {
                     IResource folderEntry = folderEntries[j];
-                    if(folderEntry instanceof IFile) {
-                        if(!udfJar) {
-                            contains=true;
+                    if(! (folderEntry instanceof IFile))
+                        continue;
+
+                    if (extension == null)
+                        return true; // found a file in the folder
+
+                    IFile file = (IFile) folderEntry;
+                    if (file.getFileExtension().equalsIgnoreCase(extension)) {
+                            contains = true;
                             break;
-                        } else if(((IFile)folderEntry).getFileExtension().equalsIgnoreCase(JAR_EXT)) {
-                            contains=true;
-                            break;
-                        }
                     }
                 }
             } catch (CoreException ex) {

--- a/plugins/org.teiid.designer.metamodels.function/src/org/teiid/designer/metamodels/function/aspects/validation/rules/ScalarFunctionRule.java
+++ b/plugins/org.teiid.designer.metamodels.function/src/org/teiid/designer/metamodels/function/aspects/validation/rules/ScalarFunctionRule.java
@@ -7,7 +7,7 @@
  */
 package org.teiid.designer.metamodels.function.aspects.validation.rules;
 
-import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.ecore.EObject;
@@ -16,6 +16,7 @@ import org.teiid.core.designer.util.CoreArgCheck;
 import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.core.ModelerCore;
 import org.teiid.designer.core.util.VdbHelper;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.core.validation.ObjectValidationRule;
 import org.teiid.designer.core.validation.ValidationContext;
 import org.teiid.designer.core.validation.ValidationProblem;
@@ -192,8 +193,8 @@ public class ScalarFunctionRule implements ObjectValidationRule {
             } else {
                 final ModelResource resrc = ModelerCore.getModelWorkspace().findModelResource(scalarFunc);
                 IProject project = resrc.getModelProject().getProject();
-                IFolder libFolder = VdbHelper.getFolder(project,VdbHelper.UDF_FOLDER);
-                boolean found = VdbHelper.isFileInFolder(libFolder,udfJarPath);
+                IContainer libFolder = VdbHelper.getFolder(project, VdbFolders.UDF.getReadFolder());
+                boolean found = VdbHelper.isFileInFolder(libFolder, udfJarPath);
                 if(!found) {
                     String message = FunctionPlugin.Util.getString("ScalarFunctionRule.udfJarNotFound",udfJarPath); //$NON-NLS-1$
                     ValidationProblem problem  = new ValidationProblemImpl(0, IStatus.ERROR ,message); 

--- a/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/aspects/validation/rules/ProcedureFunctionRule.java
+++ b/plugins/org.teiid.designer.metamodels.relational/src/org/teiid/designer/metamodels/relational/aspects/validation/rules/ProcedureFunctionRule.java
@@ -21,7 +21,7 @@ import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.core.ModelerCore;
 import org.teiid.designer.core.metamodel.aspect.AspectManager;
 import org.teiid.designer.core.metamodel.aspect.sql.SqlProcedureAspect;
-import org.teiid.designer.core.util.VdbHelper;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.core.validation.ObjectValidationRule;
 import org.teiid.designer.core.validation.ValidationContext;
 import org.teiid.designer.core.validation.ValidationProblem;
@@ -299,7 +299,7 @@ public class ProcedureFunctionRule implements ObjectValidationRule {
             if(resources!=null) {
                 for(int i=0; i<resources.length; i++) {
                     IResource theResc = resources[i];
-                    if(theResc instanceof IFolder && ((IFolder)theResc).getName().equalsIgnoreCase(VdbHelper.UDF_FOLDER)) { 
+                    if(theResc instanceof IFolder && VdbFolders.UDF.getReadFolder().equalsIgnoreCase(((IFolder)theResc).getName())) { 
                         libFolder = (IFolder)theResc;
                         break;
                     }

--- a/plugins/org.teiid.designer.relational.ui/src/org/teiid/designer/relational/ui/edit/RelationalProcedureEditorPanel.java
+++ b/plugins/org.teiid.designer.relational.ui/src/org/teiid/designer/relational/ui/edit/RelationalProcedureEditorPanel.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.layout.GridDataFactory;
@@ -45,6 +44,7 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
 import org.teiid.designer.core.ModelerCore;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.metamodels.core.ModelType;
 import org.teiid.designer.relational.RelationalConstants;
 import org.teiid.designer.relational.model.RelationalColumn;
@@ -591,9 +591,9 @@ public class RelationalProcedureEditorPanel extends RelationalEditorPanel implem
 	                @Override
 	                public void widgetSelected(SelectionEvent e) {
 	                    // Open dialog and get file
-	                    String selectedFile = VdbFileDialogUtil.selectUdfOrFile(udfJarPathBrowse.getShell(),
+	                    String selectedFile = VdbFileDialogUtil.selectFile(udfJarPathBrowse.getShell(),
 	                                                                            getModelFile().getProject(),
-	                                                                            true);
+	                                                                            VdbFolders.UDF);
 	                    getRelationalReference().setUdfJarPath(selectedFile);
 	                    handleInfoChanged();
 	                }

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewProcedureEditorPanel.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewProcedureEditorPanel.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -52,6 +51,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
 import org.teiid.core.designer.util.CoreStringUtil;
 import org.teiid.designer.core.ModelerCore;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.metamodels.core.ModelType;
 import org.teiid.designer.metamodels.relational.extension.RestModelExtensionConstants;
 import org.teiid.designer.query.sql.ISQLConstants;
@@ -738,9 +738,9 @@ public class ViewProcedureEditorPanel extends RelationalEditorPanel implements R
                     @Override
                     public void widgetSelected(SelectionEvent e) {
                         // Open dialog and get file
-                        String selectedFile = VdbFileDialogUtil.selectUdfOrFile(udfJarPathBrowse.getShell(),
+                        String selectedFile = VdbFileDialogUtil.selectFile(udfJarPathBrowse.getShell(),
                                                                                 getModelFile().getProject(),
-                                                                                true);
+                                                                                VdbFolders.UDF);
                         getRelationalReference().setUdfJarPath(selectedFile);
                         handleInfoChanged();
                     }

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/ChooseVdbFileOptionsDialog.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/ChooseVdbFileOptionsDialog.java
@@ -20,6 +20,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.teiid.core.designer.util.StringConstants;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 
 /**
  * ChooseVdbFileOptionsDialog
@@ -39,22 +41,22 @@ public class ChooseVdbFileOptionsDialog extends MessageDialog {
     private boolean selectFromWorkspace = false;
     private boolean selectFromFileSystem = false;
     private boolean copyToWorkspace = false;
-    private boolean udfJarOption = false;
+    private VdbFolders vdbFolder = null;
     private boolean disableWorkspaceOption = false;
     
     /**
      * @param parentShell the parent shell
      * @param dialogTitle the dialog title
      * @param dialogMessage the dialog message
-     * @param isUdfJar 'true' if this is a udf jar selection, 'false' for otherfiles
+     * @param vdbFolder type of folder being chosen from
      * @param disableWorkspaceOption 'true' if the workspace option is to be disabled
      */
     public ChooseVdbFileOptionsDialog( Shell parentShell,
                                String dialogTitle,
                                String dialogMessage,
-                               boolean isUdfJar, boolean disableWorkspaceOption) {
+                               VdbFolders vdbFolder, boolean disableWorkspaceOption) {
         super(parentShell, dialogTitle, null, dialogMessage, QUESTION, new String[] {IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL}, 0);
-        this.udfJarOption = isUdfJar;
+        this.vdbFolder = vdbFolder;
         this.disableWorkspaceOption=disableWorkspaceOption;
     }
 
@@ -86,11 +88,11 @@ public class ChooseVdbFileOptionsDialog extends MessageDialog {
         layout.numColumns = 1;
         radioComposite.setLayout(layout);
         
-        String selectFromWorkspaceRadioText;
-        String selectFromFileSystemRadioText;
+        String selectFromWorkspaceRadioText = StringConstants.EMPTY_STRING;
+        String selectFromFileSystemRadioText = StringConstants.EMPTY_STRING;
         
         // Change radio text based on Udf or other
-        if(this.udfJarOption) {
+        if(VdbFolders.UDF.equals(vdbFolder)) {
             selectFromWorkspaceRadioText = Messages.chooseUdfFromWorkspaceRadioText;
             selectFromFileSystemRadioText = Messages.chooseUdfFromFileSystemRadioText;
         } else {
@@ -165,49 +167,49 @@ public class ChooseVdbFileOptionsDialog extends MessageDialog {
      */
     private void setInitialDialogChoices() {
         // Udf Jar selection Mode
-        if(this.udfJarOption) {
+        if (VdbFolders.UDF.equals(vdbFolder)) {
             // if workspace option is disabled, 
             //   -initial radio choice is 'file system'
             //   -copy to workspace is checked and disabled
-            if(this.disableWorkspaceOption) {
+            if (this.disableWorkspaceOption) {
                 selectFromWorkspaceRadio.setSelection(false);
-                this.selectFromWorkspace=false;
+                this.selectFromWorkspace = false;
                 selectFromFileSystemRadio.setSelection(true);
-                this.selectFromFileSystem=true;
+                this.selectFromFileSystem = true;
                 copyToWorkspaceCheckbox.setSelection(true);
-                this.copyToWorkspace=true;
+                this.copyToWorkspace = true;
                 selectFromWorkspaceRadio.setEnabled(false);
                 copyToWorkspaceCheckbox.setEnabled(false);
-            // if workspace option is available
-            //   -initial radio choice is 'workspace'
-            //   -copy to workspace is unchecked and disabled
+                // if workspace option is available
+                //   -initial radio choice is 'workspace'
+                //   -copy to workspace is unchecked and disabled
             } else {
                 selectFromWorkspaceRadio.setSelection(true);
-                this.selectFromWorkspace=true;
+                this.selectFromWorkspace = true;
                 selectFromFileSystemRadio.setSelection(false);
-                this.selectFromFileSystem=false;
+                this.selectFromFileSystem = false;
                 copyToWorkspaceCheckbox.setSelection(false);
-                this.copyToWorkspace=false;
+                this.copyToWorkspace = false;
                 selectFromWorkspaceRadio.setEnabled(true);
                 copyToWorkspaceCheckbox.setEnabled(false);
             }
-        // File selection Mode
         } else {
+            // File selection Mode
             // -initial radio choice is 'file system'
             // -copy to workspace is unchecked
             selectFromWorkspaceRadio.setSelection(false);
-            this.selectFromWorkspace=false;
+            this.selectFromWorkspace = false;
             selectFromFileSystemRadio.setSelection(true);
-            this.selectFromFileSystem=true;
+            this.selectFromFileSystem = true;
             copyToWorkspaceCheckbox.setSelection(false);
-            this.copyToWorkspace=false;
+            this.copyToWorkspace = false;
             selectFromWorkspaceRadio.setEnabled(true);
             copyToWorkspaceCheckbox.setEnabled(true);
             // disable workspace radio if necessary
-            if(this.disableWorkspaceOption) {
+            if (this.disableWorkspaceOption) {
                 this.selectFromWorkspaceRadio.setEnabled(false);
             }
-        }        
+        }
     }
     
     /*
@@ -219,9 +221,9 @@ public class ChooseVdbFileOptionsDialog extends MessageDialog {
             this.selectFromFileSystem=true;
             this.selectFromWorkspace=false;
             // Udf from fileSystem must be copied to workspace
-            if(this.udfJarOption) {
+            if (VdbFolders.UDF.equals(vdbFolder)) {
                 this.copyToWorkspaceCheckbox.setSelection(true);
-                this.copyToWorkspace=true;
+                this.copyToWorkspace = true;
                 this.copyToWorkspaceCheckbox.setEnabled(false);
             } else {
                 this.copyToWorkspaceCheckbox.setEnabled(true);

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/UdfJarDialogCellEditor.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/UdfJarDialogCellEditor.java
@@ -12,6 +12,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.viewers.DialogCellEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.core.workspace.ModelResource;
 import org.teiid.designer.ui.viewsupport.ModelUtilities;
 
@@ -37,7 +38,7 @@ public class UdfJarDialogCellEditor extends DialogCellEditor {
         
         Object value = getValue();
         
-        String selectedFile = VdbFileDialogUtil.selectUdfOrFile(cellEditorWindow.getShell(), proj, true);
+        String selectedFile = VdbFileDialogUtil.selectFile(cellEditorWindow.getShell(), proj, VdbFolders.UDF);
         
         if( value != null && (selectedFile == null ||  selectedFile.length() == 0) ) {
         	selectedFile = (String)value;

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/VdbFileDialogUtil.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/properties/extension/VdbFileDialogUtil.java
@@ -8,112 +8,146 @@
 package org.teiid.designer.ui.properties.extension;
 
 import java.io.File;
-import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
+import org.teiid.core.designer.util.StringConstants;
 import org.teiid.designer.core.util.VdbHelper;
+import org.teiid.designer.core.util.VdbHelper.FileFilter;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.ui.actions.CopyFilesAndFoldersOperation;
 import org.teiid.designer.ui.wizards.FolderUtil;
 
 /**
  *  Methods for selecting Vdb Files (udf jars or other) from the fileSystem or workspace
  */
-public class VdbFileDialogUtil {
-    
+public class VdbFileDialogUtil implements StringConstants {
+
+    /**
+     * Allow the user total control over when type of file they want
+     * to select, eg. file system or workspace.
+     *
+     * @param shell
+     * @param project
+     * @param udfJar
+     *
+     * @return path of selected file
+     */
+    private static String chooseOptionsSelectFile(Shell shell, IProject project, VdbFolders vdbFolder) {
+        String selectedFile;
+        boolean[] choices = showOptionsDialog(shell, vdbFolder, false);
+        boolean selectFromWorkspace = false;
+        boolean copyToWorkspace = false;
+        if (choices != null) {
+            selectFromWorkspace = choices[0];
+            copyToWorkspace = choices[1];
+        } else {
+            return EMPTY_STRING;
+        }
+
+        // Show Workspace selection dialog
+        if (selectFromWorkspace) {
+            selectedFile = chooseFileFromWorkspace(shell, project, vdbFolder);
+            // Show FileSystem selection dialog
+        } else {
+            selectedFile = chooseFileFromFileSystem(shell, project, vdbFolder, copyToWorkspace);
+        }
+        return selectedFile;
+    }
+
     /**
      * Select a File for the VDB, scoped to the provided project.  The user is given the option of selecting
      * the file from the workspace(if any are present) or the file system.
+     *
      * @param shell the Shell
-     * @param proj the VDB project
-     * @param udfJar 'true' if UDF jar selection is desired, otherwise 'false' for other files
+     * @param project the VDB project
+     * @param vdbFolder type of folder requires to be selected from or null
      * @return the filePath string
      */
-    public static String selectUdfOrFile(Shell shell, IProject proj, boolean udfJar) {
-        // Determine if the desired folder is under the project
-        String folderName = udfJar ? VdbHelper.UDF_FOLDER : VdbHelper.OTHER_FILES_FOLDER; 
-        IFolder folder = VdbHelper.getFolder(proj,folderName);
-        
+    public static String selectFile(Shell shell, IProject project, VdbFolders vdbFolder) {
+
         String selectedFile = null;
+        // Determine if the desired folder is under the project
+        IContainer folder = VdbHelper.getFolder(project, vdbFolder.getReadFolder());
+
         // If the project does not contain folder
         // -- present FileSystem dialog
-        if(folder==null) {
+        if (folder == null) {
             // Udf jar selection: go to file system (must copy)
-            if(udfJar) {
-                selectedFile = chooseFileFromFileSystem(shell,proj,udfJar,true);
-            // OtherFiles selection: show choice dialog, to determine if the file needs to be copied to workspace
+            if (VdbFolders.UDF.equals(vdbFolder)) {
+                selectedFile = chooseFileFromFileSystem(shell, project, vdbFolder, true);
+                // OtherFiles selection: show choice dialog, to determine if the file needs to be copied to workspace
             } else {
-                boolean[] choices = showOptionsDialog(shell,udfJar,true); 
+                boolean[] choices = showOptionsDialog(shell, vdbFolder, true);
                 boolean copyToWorkspace = false;
-                if(choices!=null) {
+                if (choices != null) {
                     copyToWorkspace = choices[1];
                 } else {
-                    return "";  //$NON-NLS-1$
+                    return ""; //$NON-NLS-1$
                 }
-                selectedFile = chooseFileFromFileSystem(shell,proj,udfJar,copyToWorkspace);
+                selectedFile = chooseFileFromFileSystem(shell, project, vdbFolder, copyToWorkspace);
             }
-        // If the project contains folder (and at least one file in it)
-        // -- Allow file selection from folder, or FileSystem
+            // If the project contains folder (and at least one file in it)
+            // -- Allow file selection from folder, or FileSystem
         } else {
             // Determine if folder has at least one file in it.
             // -- if not, the workspace option is not available
-            if(VdbHelper.folderContainsOneOrMoreFile(folder,udfJar)) {
-                boolean[] choices = showOptionsDialog(shell,udfJar,false); 
-                boolean selectFromWorkspace = false;
-                boolean copyToWorkspace = false;
-                if(choices!=null) {
-                    selectFromWorkspace = choices[0];
-                    copyToWorkspace = choices[1];
-                } else {
-                    return "";  //$NON-NLS-1$
-                }
-                
-                // Show Workspace selection dialog
-                if(selectFromWorkspace) {
-                    selectedFile = chooseFileFromWorkspace(shell,proj,udfJar);
-                // Show FileSystem selection dialog
-                } else {
-                    selectedFile = chooseFileFromFileSystem(shell,proj,udfJar,copyToWorkspace);
-                }
-            // Workspace folder has no files.
+            if (VdbHelper.folderContainsOneOrMoreFile(folder, vdbFolder.getExtension())) {
+                selectedFile = chooseOptionsSelectFile(shell, project, vdbFolder);
+                // Workspace folder has no files.
             } else {
                 // For 'otherFiles' user has option to copyToWorkspace - show options dialog
                 // For 'udfJar' the file must be copied to the workspace
                 boolean copyToWorkspace = true;
-                if(!udfJar) {
-                    boolean[] choices = showOptionsDialog(shell,udfJar,true); 
-                    if(choices!=null) {
+                if (! VdbFolders.UDF.equals(vdbFolder)) {
+                    boolean[] choices = showOptionsDialog(shell, vdbFolder, true);
+                    if (choices != null) {
                         copyToWorkspace = choices[1];
                     } else {
-                        return "";  //$NON-NLS-1$
+                        return EMPTY_STRING;
                     }
                 }
-                selectedFile = chooseFileFromFileSystem(shell,proj,udfJar,copyToWorkspace);
+                selectedFile = chooseFileFromFileSystem(shell, project, vdbFolder, copyToWorkspace);
             }
         }
         return selectedFile;
     }
-    
+
     /*
      * Show the file vs workspace selection options dialog, and return the dialog selections.
      * If the dialog was cancelled, returns null
-     * @param udfJar this is udf jar option
+     * @param vdbFolder type of vdb folder
      * @param disableWorkspaceOption 'true' disables the option of selecting from workspace
      * @return returns boolean array
      *     - 1) 'true' if workspace selection, 'false' if fileSystem
      *     - 2) 'true' if copyToWorkspace, 'false' if not. 
      */
-    private static boolean[] showOptionsDialog(Shell shell, boolean udfJarOption, boolean disableWorkspaceOption) {
+    private static boolean[] showOptionsDialog(Shell shell, VdbFolders vdbFolder, boolean disableWorkspaceOption) {
         boolean selectFromWorkspace = false;
         boolean copyToWorkspace = false;
         
         // Show dialog for user choice
-        String title = getChooseVdbFileDialogTitle(udfJarOption);
-        String message = getChooseVdbFileDialogMessage(udfJarOption,disableWorkspaceOption);
-        ChooseVdbFileOptionsDialog optionsDialog = new ChooseVdbFileOptionsDialog(shell,title,message,udfJarOption,disableWorkspaceOption);
+        String title = EMPTY_STRING;
+        StringBuffer message = new StringBuffer();
+        if (VdbFolders.UDF.equals(vdbFolder)) {
+            title = Messages.workspaceOrFileSystemDialogUdfTitle;
+            message.append(Messages.workspaceOrFileSystemDialogUdfMessage);
+        } else {
+            title = Messages.workspaceOrFileSystemDialogFileTitle;
+            message.append(Messages.workspaceOrFileSystemDialogFileMessage);
+        }
+
+        if(disableWorkspaceOption) {
+            message.append("\n"+Messages.workspaceOptionIsDisabledMessage); //$NON-NLS-1$
+        }
+
+        ChooseVdbFileOptionsDialog optionsDialog = new ChooseVdbFileOptionsDialog(
+                                                                                  shell, title, message.toString(),
+                                                                                  vdbFolder, disableWorkspaceOption);
         
         int returnCode = optionsDialog.open();
         
@@ -126,117 +160,79 @@ public class VdbFileDialogUtil {
     }
     
     /*
-     * Get the Dialog title based on whether selecting udf jar or other files
-     * @param udfJar 'true' for udf jar selection
-     * @return the dialog title
-     */
-    private static String getChooseVdbFileDialogTitle(boolean udfJar) {
-        if(udfJar) {
-            return Messages.workspaceOrFileSystemDialogUdfTitle;
-        }
-        return Messages.workspaceOrFileSystemDialogFileTitle;
-    }
-    
-    /*
-     * Get the Dialog message based on whether selecting udf jar or other files, and
-     * add a note if workspace selection is disabled
-     * @param udfJar 'true' for udf jar selection, 'false' for other files
-     * @param disableWorkspaceOption 'true' if workspace option is not available
-     * @return the dialog message
-     */
-    private static String getChooseVdbFileDialogMessage(boolean udfJar, boolean disableWorkspaceOption) {
-        StringBuffer sb = new StringBuffer();
-        if(udfJar) {
-            sb.append(Messages.workspaceOrFileSystemDialogUdfMessage);
-        } else {
-            sb.append(Messages.workspaceOrFileSystemDialogFileMessage);
-        }
-        if(disableWorkspaceOption) {
-            sb.append("\n"+Messages.workspaceOptionIsDisabledMessage); //$NON-NLS-1$
-        }
-        return sb.toString();
-    }
-    
-    /*
      * Show dialog to select desired type of file from the FileSystem
      * @param shell the shell
      * @param project the project
-     * @param udfJar 'true' if selecting udfJars, 'false' otherwise
+     * @param vdbFolder
      * @param copyToWorkspace 'true' if copying the file into workspace folder
      * @return the selected file name
      */
-    private static String chooseFileFromFileSystem(Shell shell, IProject project, boolean udfJar, boolean copyToWorkspace) {
+    private static String chooseFileFromFileSystem(Shell shell, IProject project, VdbFolders vdbFolder, boolean copyToWorkspace) {
         String fileResult = null;
 
         final FileDialog dlg = new FileDialog(shell);
-        if(udfJar) {
-            dlg.setFilterExtensions(new String[] {"*.jar"}); //$NON-NLS-1$
-            dlg.setFilterNames(new String[] {"jar"}); //$NON-NLS-1$ 
-        } else {
-            dlg.setFilterExtensions(new String[] {"*.*"}); //$NON-NLS-1$
-            dlg.setFilterNames(new String[] {"all files"}); //$NON-NLS-1$ 
-        }
+        FileFilter fileFilter = vdbFolder == null ? VdbHelper.ALL_FILE_FILTER : vdbFolder.getFileFilter();
+        dlg.setFilterExtensions(new String[] { fileFilter.getFilter() });
+        dlg.setFilterNames(new String[] { fileFilter.getName() });
 
         String fileFullName = dlg.open();
-        if(fileFullName!=null) {
-            File theFile = new File(fileFullName);
-            String fileShortName = theFile.getName();
-           
-            // Make sure the selected file is a jar file for the udfJar option.  If not, show error dialog and return
-            if(fileShortName!=null && udfJar && !fileShortName.endsWith(".jar")) {  //$NON-NLS-1$
-                MessageDialog.openError(shell,Messages.selectedFileNotAJarDialogTitle,Messages.selectedFileNotAJarDialogMessage);
-                return ""; //$NON-NLS-1$
-            }
-            String folderName = null;
-            if(udfJar) {
-                folderName = VdbHelper.UDF_FOLDER;
-            } else {
-                folderName = VdbHelper.OTHER_FILES_FOLDER;
-            }
-            // If the appropriate folder does not exist, create it.
-            IFolder folder = VdbHelper.getFolder(project,folderName);
-            if(folder==null && copyToWorkspace) {
-                FolderUtil.createFolder(shell, project, folderName);
-                folder = VdbHelper.getFolder(project,folderName);
-            }
+        if (fileFullName == null)
+            return EMPTY_STRING;
 
-            // Now copy the selected jar into the lib folder
-            if(folder!=null && copyToWorkspace) {
-                String[] files = new String[] {fileFullName};
-                CopyFilesAndFoldersOperation operation = new CopyFilesAndFoldersOperation(shell);
-                operation.copyFiles(files, folder);
-            }
+        File theFile = new File(fileFullName);
+        String fileShortName = theFile.getName();
 
-            // If this is a 'userFile' and not copied to workspace - use full path
-            if(!udfJar && !copyToWorkspace) {
-                fileResult = fileFullName;
-            // Now lookup the file from the folder, and return the path
-            } else {
-                fileResult = VdbHelper.getFileRelativePath(folder, fileShortName);
-            }
-        } else {
-            fileResult = ""; //$NON-NLS-1$
+        // Make sure the selected file is a jar file for the udfJar option.  If not, show error dialog and return
+        if (fileShortName != null && VdbFolders.UDF.equals(vdbFolder) && !fileShortName.endsWith(VdbHelper.JAR_EXT)) {
+            MessageDialog.openError(shell, Messages.selectedFileNotAJarDialogTitle, Messages.selectedFileNotAJarDialogMessage);
+            return EMPTY_STRING;
         }
+
+        // If the appropriate folder does not exist, create it.
+        String folderName = vdbFolder.getWriteFolder();
+        IContainer folder = VdbHelper.getFolder(project, folderName);
+        if (folder == null && copyToWorkspace) {
+            FolderUtil.createFolder(shell, project, folderName);
+            folder = VdbHelper.getFolder(project, folderName);
+        }
+
+        // Now copy the selected file into the folder
+        if (folder != null && copyToWorkspace) {
+            String[] files = new String[] {fileFullName};
+            CopyFilesAndFoldersOperation operation = new CopyFilesAndFoldersOperation(shell);
+            operation.copyFiles(files, folder);
+        }
+
+        // If this is a 'userFile' and not copied to workspace - use full path
+        if (!VdbFolders.UDF.equals(vdbFolder) && !copyToWorkspace) {
+            fileResult = fileFullName;
+            // Now lookup the file from the folder, and return the path
+        } else {
+            fileResult = VdbHelper.getFileRelativePath(folder, fileShortName);
+        }
+
         return fileResult;
     }
 
     /*
      * Show dialog to select a file from the workspace
-     * @param cellEditorWindow the window control
+     *
      * @return the selected file name from the workspace
      */
-    private static String chooseFileFromWorkspace(Shell shell, IProject project, boolean udfJar) {
+    private static String chooseFileFromWorkspace(Shell shell, IProject project, VdbFolders vdbFolder) {
         String fileName = null;
         String title = null;
         String message = null;
-        if(udfJar) {
+        if (VdbFolders.UDF.equals(vdbFolder)) {
             title = Messages.chooseFileFromWorkspaceDialogUdfTitle;
             message = Messages.chooseFileFromWorkspaceDialogUdfMessage;
         } else {
             title = Messages.chooseFileFromWorkspaceDialogFileTitle;
             message = Messages.chooseFileFromWorkspaceDialogFileMessage;
         }
-        final ChooseVdbFileFromWorkspaceDialog dlg = new ChooseVdbFileFromWorkspaceDialog(shell,title,message,project,udfJar);
+        final ChooseVdbFileFromWorkspaceDialog dlg = new ChooseVdbFileFromWorkspaceDialog(
+                                                                                          shell, title, message,
+                                                                                          project, vdbFolder);
         
         final IResource choice = dlg.open() == Window.OK ? (IResource)dlg.getFirstResult() : null;
         if (choice != null) fileName = choice.getProjectRelativePath().toString();

--- a/plugins/org.teiid.designer.vdb.ui/plugin.xml
+++ b/plugins/org.teiid.designer.vdb.ui/plugin.xml
@@ -122,7 +122,15 @@
 	      class="org.teiid.designer.vdb.ui.build.VdbDifferentServerVersionResolutionGenerator" 
 	      markerType="org.teiid.designer.vdb.ui.vdbMarker"> 
           <attribute name="differentValidationVersion" value="true"/>
-       </markerResolutionGenerator> 
+       </markerResolutionGenerator>
+    <markerResolutionGenerator
+          class="org.teiid.designer.vdb.ui.build.VdbDuplicateNamesMarkerResolutionGenerator"
+          markerType="org.teiid.designer.vdb.ui.vdbMarker">
+       <attribute
+             name="duplicateModelNames"
+             value="true">
+       </attribute>
+    </markerResolutionGenerator>
 	</extension>
 	  <extension
          point="org.teiid.designer.core.refactorModelHandler">

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/Messages.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/Messages.java
@@ -28,7 +28,8 @@ public class Messages  extends NLS {
 	public static String synchronizeVdbLabel;
 	public static String extractMissingModelsLabel;
 	public static String extractMissingModelsAndSyncLabel;
-	
+	public static String migrateXsdFilesFromModelsToOtherLabel;
+
 	public static String modelDetailsPanel_modelDetails;
 	public static String modelDetailsPanel_modelDetailsTooltip;
 	public static String noSelection;

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbBuilder.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbBuilder.java
@@ -10,12 +10,10 @@ package org.teiid.designer.vdb.ui.build;
 
 import static org.teiid.designer.vdb.ui.VdbUiConstants.PLUGIN_ID;
 import static org.teiid.designer.vdb.ui.VdbUiConstants.Util;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -62,7 +60,7 @@ public class VdbBuilder extends AbstractTeiidProjectBuilder {
 	@SuppressWarnings("javadoc")
 	public static final String MODEL_WITH_ERRORS = "modelWithErrors"; //$NON-NLS-1$
 	@SuppressWarnings("javadoc")
-	public static final String DUPLICATE_FILE_NAMES = "duplicateModelNames"; //$NON-NLS-1$
+	public static final String DUPLICATE_MODEL_NAMES = "duplicateModelNames"; //$NON-NLS-1$
 	@SuppressWarnings("javadoc")
 	public static final String SINGLE_AUTHENTICATION_TYPE_IGNORED = "singleAuthenticationTypeIgnored"; //$NON-NLS-1$
 	
@@ -200,7 +198,7 @@ Read more: http://javarevisited.blogspot.com/2011/08/enum-in-java-example-tutori
     					createMarker(vdbFile, IMarker.SEVERITY_ERROR, iStatus.getMessage(), VdbUiConstants.VdbIds.PROBLEM_MARKER, MarkerType.MISSING_TRANSLATOR_TYPE);
     				} else if( iStatus.getMessage().indexOf("and will not be ACTIVE") > 0 ) { //$NON-NLS-1$
     					createMarker(vdbFile, IMarker.SEVERITY_ERROR, iStatus.getMessage(), VdbUiConstants.VdbIds.PROBLEM_MARKER, MarkerType.MODEL_WITH_ERRORS);
-    				} else if(iStatus.getMessage().indexOf("The VDB cannot contain models") > 0 ) { //$NON-NLS-1$
+    				} else if(iStatus.getMessage().indexOf("VDB cannot contain models") > 0 ) { //$NON-NLS-1$
     					createMarker(vdbFile, IMarker.SEVERITY_ERROR, iStatus.getMessage(), VdbUiConstants.VdbIds.PROBLEM_MARKER, MarkerType.DUPLICATE_MODEL_NAMES);
     				} else {
     					createMarker(vdbFile, IMarker.SEVERITY_ERROR, iStatus.getMessage(), VdbUiConstants.VdbIds.PROBLEM_MARKER, MarkerType.DEFAULT);
@@ -244,6 +242,8 @@ Read more: http://javarevisited.blogspot.com/2011/08/enum-in-java-example-tutori
 			attributes.put(MISSING_MODEL, true);
 		} else if (markerType == MarkerType.DIFFERENT_VALIDATION_VERSION) {
 			attributes.put(DIFFERENT_VALIDATION_VERSION, true);
+		} else if (markerType == MarkerType.DUPLICATE_MODEL_NAMES) {
+		    attributes.put(DUPLICATE_MODEL_NAMES, true);
 		}
 		
 		attributes.put(IMarker.LOCATION, file.getName());

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbDuplicateNamesMarkerResolutionGenerator.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbDuplicateNamesMarkerResolutionGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.teiid.designer.vdb.ui.build;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.ui.IMarkerResolution;
+
+/**
+ * Quick fix to move xsd files from the VDB model collection into its
+ * other files collection
+ */
+public class VdbDuplicateNamesMarkerResolutionGenerator extends VdbMarkerResolutionGenerator {
+
+    @Override
+    public IMarkerResolution[] getResolutions(IMarker marker) {
+        Collection<IMarkerResolution> resolutions = new ArrayList<IMarkerResolution>();
+
+        if( marker.getAttribute(VdbBuilder.DUPLICATE_MODEL_NAMES, false)) {
+            resolutions.add(new VdbMigrateXsdFilesMarkerResolution());
+        }
+
+        return resolutions.toArray(new IMarkerResolution[resolutions.size()]);
+    }
+}

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbMigrateXsdFilesMarkerResolution.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/build/VdbMigrateXsdFilesMarkerResolution.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.teiid.designer.vdb.ui.build;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IMarkerResolution;
+import org.teiid.designer.ui.common.viewsupport.UiBusyIndicator;
+import org.teiid.designer.vdb.Vdb;
+import org.teiid.designer.vdb.VdbConstants;
+import org.teiid.designer.vdb.ui.Messages;
+
+/**
+ *
+ */
+public class VdbMigrateXsdFilesMarkerResolution implements IMarkerResolution {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.ui.IMarkerResolution#getLabel()
+     */
+    @Override
+    public String getLabel() {
+        return Messages.migrateXsdFilesFromModelsToOtherLabel;
+    }
+
+    /**
+     * @param resource the resource being checked (never <code>null</code>)
+     * @return <code>true</code> if resource is a VDB file
+     */
+    private boolean isVdbFile(IResource resource) {
+        return ((resource.getType() == IResource.FILE) && VdbConstants.VDB_FILE_EXTENSION.equals(resource.getFileExtension()) && resource.exists());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.ui.IMarkerResolution#run(org.eclipse.core.resources.IMarker)
+     */
+    @Override
+    public void run(IMarker marker) {
+        IResource resource = marker.getResource();
+
+        // Fix the Marked Model Resource
+        if (! isVdbFile(resource))
+            return;
+
+        final IFile theVdbFile = (IFile)resource;
+
+        UiBusyIndicator.showWhile(Display.getDefault(), new Runnable() {
+            @Override
+            public void run() {
+                fixVdb(theVdbFile);
+            }
+        });
+    }
+
+    void fixVdb(IFile theVdb) {
+        NullProgressMonitor monitor = new NullProgressMonitor();
+        Vdb vdb = new Vdb(theVdb, false, monitor);
+
+        vdb.migrateXsdFiles(monitor);
+
+        vdb.save(monitor);
+
+        try {
+            theVdb.refreshLocal(IResource.DEPTH_ZERO, monitor);
+        } catch (CoreException ex) {
+            // No need to log this
+        }
+    }
+}

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/messages.properties
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/messages.properties
@@ -22,6 +22,7 @@ fixVdbPath_OpenEditorMessage= VDB editor for "{0}" will be closed before before 
 synchronizeVdbLabel = Synchronize VDB
 extractMissingModelsLabel = Extract missing models into project
 extractMissingModelsAndSyncLabel = Extract missing models into project and synchronize VDB
+migrateXsdFilesFromModelsToOtherLabel=Migrate VDB's Xsd files from "Models" to "Other Files"
 
 modelDetailsPanel_modelDetails=Model Details
 modelDetailsPanel_modelDetailsTooltip=Detailed properties for the selected model file in VDB
@@ -37,5 +38,4 @@ modelDetailsPanel_problemsTabLabel=Problems
 modelDetailsPanel_problemsTabTooltip=Errors and warnings associated with the selected model
 modelDetailsPanel_problemPathLabel=Object Path
 modelDetailsPanel_problemDescriptionLabel=Description
-
 	

--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbFileEntry.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbFileEntry.java
@@ -16,7 +16,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.teiid.designer.core.util.VdbHelper;
+import org.teiid.core.designer.util.StringConstants;
+import org.teiid.designer.core.util.VdbHelper.VdbFolders;
 import org.teiid.designer.vdb.manifest.EntryElement;
 
 
@@ -55,7 +56,7 @@ public final class VdbFileEntry extends VdbEntry {
      * @param entryType the type of FileEntry
      * @param monitor the progress monitor or <code>null</code>
      */
-    VdbFileEntry( final Vdb vdb,
+    public VdbFileEntry( final Vdb vdb,
                   final IPath sourcePath,
                   final FileEntryType entryType,
                   final IProgressMonitor monitor ) {
@@ -83,9 +84,9 @@ public final class VdbFileEntry extends VdbEntry {
         super(vdb, Path.fromPortableString(element.getPath()), monitor);
         
         this.sourceFilePath = Path.fromPortableString(element.getPath());
-        if(element.getPath().startsWith("/"+VdbHelper.UDF_FOLDER)) {  //$NON-NLS-1$
+        if(element.getPath().startsWith(StringConstants.FORWARD_SLASH + VdbFolders.UDF.getReadFolder())) {
             this.fileType = FileEntryType.UDFJar;
-        } else if(element.getPath().startsWith("/"+VdbHelper.OTHER_FILES_FOLDER)) { //$NON-NLS-1$
+        } else {
             this.fileType = FileEntryType.UserFile;
         }
         
@@ -96,9 +97,9 @@ public final class VdbFileEntry extends VdbEntry {
     private IPath determinePath(IPath sourcePath,FileEntryType entryType) {
         String fileName = sourcePath.lastSegment();
         if(entryType==FileEntryType.UserFile) {
-            return new Path("/"+VdbHelper.OTHER_FILES_FOLDER+"/"+fileName);  //$NON-NLS-1$ //$NON-NLS-2$
+            return new Path(StringConstants.FORWARD_SLASH + VdbFolders.OTHER_FILES.getReadFolder() + StringConstants.FORWARD_SLASH + fileName);  
         } else if(entryType==FileEntryType.UDFJar) {
-            return new Path("/"+VdbHelper.UDF_FOLDER+"/"+fileName);  //$NON-NLS-1$ //$NON-NLS-2$
+            return new Path(StringConstants.FORWARD_SLASH + VdbFolders.UDF.getReadFolder() + StringConstants.FORWARD_SLASH + fileName);  
         }
         return null;
     }
@@ -110,7 +111,7 @@ public final class VdbFileEntry extends VdbEntry {
         String zipName = getName().toString();
         // Need to strip off the leading delimeter if it exists, else a "jar" extract command will result in models
         // being located at the file system "root" folder.
-        if( zipName.startsWith("/") ) { //$NON-NLS-1$
+        if(zipName.startsWith(StringConstants.FORWARD_SLASH)) {
             zipName = zipName.substring(1, zipName.length());
         }
         final ZipEntry zipEntry = new ZipEntry(zipName);

--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/ModelElement.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/ModelElement.java
@@ -14,10 +14,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import org.teiid.designer.vdb.VdbEntry;
 import org.teiid.designer.vdb.VdbModelEntry;
+import org.teiid.designer.vdb.VdbModelEntry.Problem;
 import org.teiid.designer.vdb.VdbSource;
 import org.teiid.designer.vdb.VdbUtil;
-import org.teiid.designer.vdb.VdbModelEntry.Problem;
 
 /**
  * 
@@ -128,7 +129,7 @@ public class ModelElement extends EntryElement {
         		props.add(new PropertyElement(MULTI_SOURCE_COLUMN_ALIAS, alias));
         	}
         }
-        for (final VdbModelEntry importedEntry : entry.getImports())
+        for (final VdbEntry importedEntry : entry.getImports())
             props.add(new PropertyElement(IMPORTS, importedEntry.getName().toString()));
         for (final String importedVdbName : entry.getImportVdbNames())
             props.add(new PropertyElement(IMPORT_VDB_REFERENCE, importedVdbName));

--- a/plugins/org.teiid.designer.vdb/vdb-deployer.xsd
+++ b/plugins/org.teiid.designer.vdb/vdb-deployer.xsd
@@ -174,10 +174,14 @@
 			<xs:attribute name="name" type="xs:string" use="required"/>
 			<xs:attribute name="version" type="xs:int" use="required"/>
 		</xs:complexType>
-		<xs:unique name="modelNameUnique">
+        <!--
+            Commented out due to TEIIDDES-2021. The spirit of the constraint
+            is already implemented in designer code
+         -->
+		<!-- <xs:unique name="modelNameUnique">
 			<xs:selector xpath="model"/>
 			<xs:field xpath="@name"/>
-		</xs:unique>
+		</xs:unique> -->
 		<xs:unique name="importUnique">
 			<xs:selector xpath="import-vdb"/>
 			<xs:field xpath="@name"/>


### PR DESCRIPTION
- VdbHelper
  - Replace static strings with VdbFolder enum that also incorporates a file
    filter, read and write folders
  - getFolder() should be able to return the project as the 'root folder'
    given a suitable folderName, ie. ".". Does imply that the return object
    must be a container rather than a folder
  - Other Files enum only references otherFiles directory when creating and
    adding a file from the filesystem. When reading from the project it
    searches from the root of the project. Necessary since Xsd files can
    appear anywhere in the project.
- VdbFileDialogUtil
  - Passes into methods VdbFolders enum value instead of vague boolean flag
- plugin.xml
- VdbBuilder
- VdbDuplicateNamesMarkerResolutionGenerator
- VdbMigrateXsdFilesMarkerResolution
  - Provides a quick fix to migrate Xsd files from the vdb's models
    collection to its otherFiles collection
- VdbEditor
  - Refactor duplicate code into single addSelectionToVdb method
- Vdb
  - Provides API for migrating Xsd files from the models collection to the
    other files collection and deleting the index file
- VdbModelEntry
  - Broadens scope of imports collection to contain file entries as well as
    model entries
  - replaceImport method to replace import entry references
- vdb-deployer.xsd
  - Comments out the constraint that stops vdbs from containing duplicate
    named models. This logic is already implemented in code and designer
    must support old vdbs that may contain such duplicate models and give
    the user the chance to fix them.
