### PR TITLE
teiiddes-2162

### DIFF
--- a/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/SchemaTreeModel.java
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/SchemaTreeModel.java
@@ -19,6 +19,7 @@ import org.eclipse.xsd.XSDTypeDefinition;
 import org.eclipse.xsd.impl.XSDElementDeclarationImpl;
 import org.eclipse.xsd.impl.XSDModelGroupImpl;
 import org.eclipse.xsd.impl.XSDParticleImpl;
+import org.teiid.core.designer.util.StringUtilities;
 import org.teiid.designer.modelgenerator.wsdl.model.Part;
 
 
@@ -295,6 +296,7 @@ public class SchemaTreeModel {
 			}
 		}
 		
+		if (nsPrefix==null) nsPrefix=StringUtilities.EMPTY_STRING;
 		//  This is default.. no need to alias
 		//	if (nsPrefix.equals(ResponseInfo.DEFAULT_NS)) nsPrefix = ""; //$NON-NLS-1$ //$NON-NLS-2$
 		//  We will always prefix, since we can't count on a service default for a given element

--- a/plugins/org.teiid.designer.schema.tools/src/org/teiid/designer/schema/tools/processing/internal/SchemaProcessorImpl.java
+++ b/plugins/org.teiid.designer.schema.tools/src/org/teiid/designer/schema/tools/processing/internal/SchemaProcessorImpl.java
@@ -343,8 +343,9 @@ public class SchemaProcessorImpl implements SchemaProcessor {
     public XSDTypeDefinition resolveElementType( XSDElementDeclaration elem,
                                                  ElementContentTraversalContext traverseCtx ) throws SchemaProcessingException {
         XSDTypeDefinition type = elem.getType();
+        //Type is an optional attribute, so we will return null if it is not there.
         if (null == type) {
-            throw new SchemaProcessingException(ToolsPlugin.Util.getString("SchemaProcessor.no.type.declaration", elem.getName())); //$NON-NLS-1$
+        	return null;
         }
         return resolveType(type, traverseCtx);
     }

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/proc/wsdl/WsdlResponseProcedureHelper.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/proc/wsdl/WsdlResponseProcedureHelper.java
@@ -132,7 +132,7 @@ public class WsdlResponseProcedureHelper extends AbstractWsdlHelper implements I
         sb.append(XMLNAMESPACES).append(L_PAREN);
         int i = 0;
         for (Entry<String, String> entry : namespaceMap.entrySet()) {
-            if (entry.getKey().equalsIgnoreCase(XSI_NAMESPACE_PREFIX)) {
+            if (entry.getKey()==null || entry.getKey().equalsIgnoreCase(XSI_NAMESPACE_PREFIX)) {
                 continue;
             }
             


### PR DESCRIPTION
http://www.restfulwebservices.net/wcf/StockQuoteService.svc?wsdl was getting an NPE due to the schema imports not having a namespace prefix. Since prefix is an optional attribute for import, I added a check for null.

http://ws.cdyne.com/delayedstockquote/delayedstockquote.asmx?WSDL was failing to parse because we were expecting a "type" attribute on the element. "Type" is an optional attribute on element, so I have relaxed the requirement in the code.
