### PR TITLE
Issues with Excel Import

### DIFF
--- a/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/convertor/MxdConvertor.java
+++ b/plugins/org.teiid.designer.extension/src/org/teiid/designer/extension/convertor/MxdConvertor.java
@@ -35,7 +35,7 @@ public class MxdConvertor {
 
     private static final String SCHEMA_LOCATION = "http://www.jboss.org/teiiddesigner/ext/2012 http://www.jboss.org/teiiddesigner/ext/2012/modelExtension.xsd"; //$NON-NLS-1$
 
-    private static final String NAMESPACE_URI = "http://www.jboss.org/teiiddesigner/ext/{NAME}/2014"; //$NON-NLS-1$
+    private static final String NAMESPACE_URI = "http://www.teiid.org/translator/{NAME}/2014"; //$NON-NLS-1$
 
     private static MxdConvertor INSTANCE;
 
@@ -163,6 +163,16 @@ public class MxdConvertor {
             return false;
 
         String name = translator.getName();
+        // HACK - fixes erroneous excel extension until TEIID-2974 is fixed and available to Designer
+        if(name!=null && name.equals("excel")) {  //$NON-NLS-1$
+        	for(TeiidPropertyDefinition extDefn : extensions) {
+        		String extName = extDefn.getName();
+        		if(extName!=null && extName.endsWith("FIRST_DATA_ROW_NUMBER")) { //$NON-NLS-1$
+        			extDefn.setOwner("org.teiid.metadata.Table"); //$NON-NLS-1$
+        		}
+        	}
+        }
+        
         try {
             ModelType.Type modelType = ModelType.Type.PHYSICAL;
             Collection<MetaclassType> metaClasses = read(extensions);

--- a/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/TeiidImportManager.java
+++ b/plugins/org.teiid.designer.teiidimporter.ui/src/org/teiid/designer/teiidimporter/ui/wizard/TeiidImportManager.java
@@ -788,7 +788,7 @@ public class TeiidImportManager implements ITeiidImportServer, UiConstants {
         	// Use the importer to process the difference report, generating the model
             if (ddlImporter.getDifferenceReport() == null) return false;
 
-            final Exception[] saveException = new Exception[0];
+            final Exception[] saveException = new Exception[1];
             new ProgressMonitorDialog(shell).run(false, false, new IRunnableWithProgress() {
 
                 @Override


### PR DESCRIPTION
- Made changes to TeiidDdlImporter to handle the extension properties.  The AstNodes for extension properties will be namespaced with the teiid namespace URI, (if it is available - with addition of Option Namespace statement).  That is the primary way we should resolve against our Designer MEDS - check for NS URI match to the registered MEDS.  The changes also handle the standard NS prefixes - (as fallback) until the teiid NS statements make it into the DDL.
- TeiidImportManager resolves Array OOB exception encountered
- MxdConvertor - changed the URI template for generated MEDS to match the expected teiid URIs.  There is also a HACK to fix error resulting from TEIID-2974 until teiid gets their fix in.
