### PR TITLE
DDL importer generates inaccurate model

### DIFF
--- a/plugins/org.teiid.designer.ddl.importer/src/org/teiid/designer/ddl/importer/node/MySQLImporter.java
+++ b/plugins/org.teiid.designer.ddl.importer/src/org/teiid/designer/ddl/importer/node/MySQLImporter.java
@@ -7,16 +7,19 @@
 */
 package org.teiid.designer.ddl.importer.node;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.mysql.MySqlDdlLexicon;
 import org.modeshape.sequencer.ddl.node.AstNode;
 import org.teiid.designer.relational.model.RelationalIndex;
 import org.teiid.designer.relational.model.RelationalModel;
 import org.teiid.designer.relational.model.RelationalReference;
 import org.teiid.designer.relational.model.RelationalSchema;
+import org.teiid.designer.relational.model.RelationalTable;
 
 /**
  *
@@ -54,9 +57,25 @@ public class MySQLImporter extends StandardImporter {
      */
     @Override
 	protected void createDeferredObjects(Map<AstNode,RelationalReference> deferredNodes, RelationalModel model) throws Exception {
+		Collection<RelationalReference> allRefs = model.getAllReferences();
 
-    	Set<AstNode> astNodes = deferredNodes.keySet();
-    	for(AstNode node:astNodes) {
+		// Make first pass to create the PKs
+		Set<AstNode> astNodes = deferredNodes.keySet();
+		for(AstNode node:astNodes) {
+			if (is(node, StandardDdlLexicon.TYPE_TABLE_CONSTRAINT)) {
+				RelationalTable table = (RelationalTable)deferredNodes.get(node);
+				createPrimaryKey(node, table, allRefs);
+			} else if (is(node, StandardDdlLexicon.TYPE_ALTER_TABLE_STATEMENT)) {
+				RelationalTable table = find(RelationalTable.class, node, null, allRefs);
+				for (AstNode node1 : node) {
+					if (is(node1, StandardDdlLexicon.TYPE_ADD_TABLE_CONSTRAINT_DEFINITION)) 
+						createPrimaryKey(node1, table, allRefs);
+				}
+			}
+		}
+
+		// Second pass create other constraints
+		for(AstNode node:astNodes) {
             if (is(node, MySqlDdlLexicon.TYPE_CREATE_INDEX_STATEMENT)) {
                 RelationalIndex index = getFactory().createIndex();
                 Info info = createInfo(node, model);
@@ -66,8 +85,19 @@ public class MySQLImporter extends StandardImporter {
                     info.getSchema().getIndexes().add(index);
 
                 initialize(index, node, info.getName());
-            } 
-    	}
+            } else if (is(node, StandardDdlLexicon.TYPE_TABLE_CONSTRAINT)) {
+				RelationalTable table = (RelationalTable)deferredNodes.get(node);
+				createConstraint(node, table, allRefs);
+			} else if (is(node, StandardDdlLexicon.TYPE_ALTER_TABLE_STATEMENT)) {
+				RelationalTable table = find(RelationalTable.class, node, null, allRefs);
+				for (AstNode node1 : node) {
+					if (is(node1, StandardDdlLexicon.TYPE_ADD_TABLE_CONSTRAINT_DEFINITION)) 
+						createConstraint(node1, table, allRefs);
+					else if (is(node1, StandardDdlLexicon.TYPE_ADD_COLUMN_DEFINITION))
+						createColumn(node1, table);
+				}
+			}
+		}
     }
     
 }


### PR DESCRIPTION
- any DDL importer that overrides the StandardDdlImporter createDeferredObjects method must include the handling in StandardDdlImporter as well as handling for its specific nodes.  Re-worked the Derby, MySQL, Oracle and Postgres importers createDeferredObjects methods.
- also added specific type handling in the Oracle and Postgres importers to allow their non-standard types to get mapped properly. 
