### PR TITLE
TEIIDDES-2207: Correct Web Service issue when view lacks a primary key

### DIFF
--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
@@ -2098,6 +2098,9 @@ public class SQLStringVisitor extends LanguageVisitor
     }
 
     private void registerNodes(List<? extends LanguageObject> objects, int begin) {
+        if (objects == null)
+            return;
+
         for (int i = begin; i < objects.size(); i++) {
             if (i > 0) {
                 append(", "); //$NON-NLS-1$


### PR DESCRIPTION
- When a view model lacks a primary key, the model lacks an input element
- WebServiceBuilderHelper
  - Refactor the SQL generation function to only create declarations and
    assignment if the model has any input elements.
  - Removes default 'example' SQL since this is not valid and likely to
    provide nothing but confusion to users
- SQLStringVisitor
  - Avoids possible NPE when the object list is null
