### PR TITLE
Partial revert of 9fb51aecd8e4debd4421791a37e091afc708a8ed

### DIFF
--- a/plugins/teiid/org.teiid.runtime.client/client/org/teiid/net/socket/AuthenticationType.java
+++ b/plugins/teiid/org.teiid.runtime.client/client/org/teiid/net/socket/AuthenticationType.java
@@ -22,52 +22,7 @@
 
 package org.teiid.net.socket;
 
-import org.teiid.designer.annotation.Removed;
-import org.teiid.designer.annotation.Since;
-import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
-import org.teiid.designer.runtime.version.spi.TeiidServerVersion.Version;
 
 public enum AuthenticationType {
-    @Since(Version.TEIID_8_7)
-    USERPASSWORD,
-
-    GSS,
-
-    @Removed(Version.TEIID_8_7)
-    CLEARTEXT;
-
-    private static boolean lessThan87(ITeiidServerVersion teiidVersion) {
-        return teiidVersion.isLessThan(Version.TEIID_8_7.get());
-    }
-
-    /**
-     * @param teiidVersion
-     * @param readByte
-     *
-     * @return enum value
-     */
-    public static AuthenticationType value(ITeiidServerVersion teiidVersion, byte readByte) {
-        switch (readByte) {
-            case 0:
-                if (lessThan87(teiidVersion))
-                    return CLEARTEXT;
-                else
-                    return USERPASSWORD;
-            case 1:
-                return GSS;
-            default:
-                throw new IllegalStateException();
-        }
-    }
-
-    /**
-     * @param teiidVersion
-     * @return Same as ordinal but handle deprecated inclusion of CLEARTEXT
-     */
-    public int index(ITeiidServerVersion teiidVersion) {
-        if (lessThan87(teiidVersion) && this == CLEARTEXT)
-            return 0;
-
-        return this.ordinal();
-    }
+    USERPASSWORD, GSS;
 }

--- a/plugins/teiid/org.teiid.runtime.client/client/org/teiid/net/socket/Handshake.java
+++ b/plugins/teiid/org.teiid.runtime.client/client/org/teiid/net/socket/Handshake.java
@@ -32,7 +32,6 @@ import org.teiid.core.util.ApplicationInfo;
 import org.teiid.core.util.StringUtil;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
 import org.teiid.designer.runtime.version.spi.TeiidServerVersion;
-import org.teiid.designer.runtime.version.spi.TeiidServerVersion.Version;
 
 
 /**
@@ -57,18 +56,6 @@ public class Handshake implements Externalizable {
     private ITeiidServerVersion getTeiidVersion() {
         ITeiidServerVersion version = new TeiidServerVersion(getVersion());
         return version;
-    }
-
-    private AuthenticationType getAuthenticationType() {
-        if (authType == null) {
-            ITeiidServerVersion version = getTeiidVersion();
-            if (version.isGreaterThanOrEqualTo(Version.TEIID_8_7.get()))
-                authType = AuthenticationType.USERPASSWORD;
-
-            authType = AuthenticationType.CLEARTEXT;
-        }
-
-        return authType;
     }
 
     /** 
@@ -116,8 +103,12 @@ public class Handshake implements Externalizable {
     }
     
     public AuthenticationType getAuthType() {
-		return getAuthenticationType();
+		return authType;
 	}
+
+    public void setAuthType(AuthenticationType authType) {
+        this.authType = authType;
+    }
 
     @Override
     public void readExternal(ObjectInput in) throws IOException,
@@ -125,7 +116,7 @@ public class Handshake implements Externalizable {
     	version = (String)in.readObject();
     	publicKey = (byte[])in.readObject();
     	try {
-    		authType = AuthenticationType.value(getTeiidVersion(), in.readByte());
+    		authType = AuthenticationType.values()[in.readByte()];
     	} catch (EOFException e) {
     		
     	}
@@ -135,7 +126,7 @@ public class Handshake implements Externalizable {
     public void writeExternal(ObjectOutput out) throws IOException {
     	out.writeObject(version);
     	out.writeObject(publicKey);
-    	out.writeByte(authType.index(getTeiidVersion()));
+    	out.writeByte(authType.ordinal());
     }
     
 }


### PR DESCRIPTION
- The AuthenticationType CLEARTEXT was not a fully different option but a
  simple name change for USERPASSWORD and was never included in a final
  release.
- Reverts both AuthenticationType and Handshake to reflect 8.7 teiid client
