### PR TITLE
TEIIDDES-2276 Resolve XML File Importer issue on Windows

### DIFF
--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/TeiidXmlFileInfo.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/TeiidXmlFileInfo.java
@@ -92,7 +92,7 @@ public class TeiidXmlFileInfo extends TeiidFileInfo implements UiConstants, ITei
 	 */
 	private List<TeiidXmlColumnInfo> columnInfoList;
 	
-	private Map<String, Object> parameterMap;
+	private Map<String, Object> parameterMap = new HashMap<String,Object>();
  	
 	private XmlElement rootNode;
 	

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/XmlElement.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/XmlElement.java
@@ -17,7 +17,7 @@ import org.eclipse.jface.text.Position;
  * @since 8.0
  */
 public class XmlElement {
-	private final String SEPARATOR = "/";  //$NON-NLS-1$
+	public static final String SEPARATOR = "/";  //$NON-NLS-1$
 	private List<XmlElement> elementChildren = new ArrayList<XmlElement>();
 	private List<XmlAttribute> attributeChildren = new ArrayList<XmlAttribute>();
 

--- a/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/proc/ProcedureService.java
+++ b/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/proc/ProcedureService.java
@@ -296,7 +296,10 @@ public class ProcedureService implements IProcedureService, ISQLConstants {
     	 List<String> tokens = new ArrayList<String>();
          List<ITeiidXmlColumnInfo> columnInfoList = xmlFileInfo.getColumnInfoList();
          
-         boolean isJson = xmlFileInfo.getResponseType().toUpperCase().equals(JSON);
+         boolean isJson = false;
+         if(xmlFileInfo.getResponseType()!=null && xmlFileInfo.getResponseType().toUpperCase().equals(JSON)) {
+        	 isJson = true;
+         }
          Map<String, Parameter> parameters = xmlFileInfo.getParameterMap();
 
          boolean isQueryParm = false;


### PR DESCRIPTION
- Eliminate path usage in TeiidXmlColumnInfo, due to issues on windows with namespaced elements.  The ':' causes issues on windows because they are considered drive separator with path usage.
- couple other minor changes in other classes.
