### PR TITLE
TEIIDDES-2295 Fixes several windows specific issues

### DIFF
--- a/plugins/org.teiid.designer.roles.ui/src/org/teiid/designer/roles/ui/wizard/panels/CrudPanel.java
+++ b/plugins/org.teiid.designer.roles.ui/src/org/teiid/designer/roles/ui/wizard/panels/CrudPanel.java
@@ -50,7 +50,7 @@ public class CrudPanel extends DataRolePanel {
 	 */
 	@Override
 	void createControl() {
-        treeViewer = new TreeViewer(getPrimaryPanel(), SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
+        treeViewer = new TreeViewer(getPrimaryPanel(), SWT.MULTI | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL);
         Tree tree = treeViewer.getTree();
 
         final GridData gridData = new GridData(GridData.FILL_BOTH);

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewProcedureEditorPanel.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewProcedureEditorPanel.java
@@ -420,12 +420,12 @@ public class ViewProcedureEditorPanel extends RelationalEditorPanel implements R
     		
 		});
 
-    	Table columnTable = new Table(thePanel, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER );
+        this.columnsViewer = new TableViewer(thePanel, SWT.SINGLE | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
+    	Table columnTable = this.columnsViewer.getTable();
     	columnTable.setHeaderVisible(true);
     	columnTable.setLinesVisible(true);
     	columnTable.setLayout(new TableLayout());
 
-        this.columnsViewer = new TableViewer(columnTable);
         GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 100).applyTo(this.columnsViewer.getControl());
 
         // create columns
@@ -534,7 +534,7 @@ public class ViewProcedureEditorPanel extends RelationalEditorPanel implements R
 				gd.horizontalSpan=4;
 				restGroup.setLayoutData(gd);
 				
-				this.applyRestWarPropertiesCB = WidgetFactory.createCheckBox(restGroup, Messages.enableRestForThisProcedure); //$NON-NLS-1$
+				this.applyRestWarPropertiesCB = WidgetFactory.createCheckBox(restGroup, Messages.enableRestForThisProcedure);
 				this.applyRestWarPropertiesCB.setEnabled(true);
 				this.applyRestWarPropertiesCB.setSelection(true);
 
@@ -1006,12 +1006,12 @@ public class ViewProcedureEditorPanel extends RelationalEditorPanel implements R
     		
 		});
     	
-    	Table columnTable = new Table(thePanel, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER );
+    	this.parametersViewer = new TableViewer(thePanel, SWT.SINGLE | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
+    	Table columnTable = this.parametersViewer.getTable();
     	columnTable.setHeaderVisible(true);
     	columnTable.setLinesVisible(true);
     	columnTable.setLayout(new TableLayout());
     	
-        this.parametersViewer = new TableViewer(columnTable);
         GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 150).applyTo(this.parametersViewer.getControl());
 
         // create columns

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewTableEditorPanel.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/editors/ViewTableEditorPanel.java
@@ -1096,12 +1096,12 @@ public class ViewTableEditorPanel extends RelationalEditorPanel implements Relat
     		
 		});
     	
-    	Table columnTable = new Table(thePanel, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER );
+    	this.columnsViewer = new TableViewer(thePanel, SWT.SINGLE | SWT.FULL_SELECTION |SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER );
+    	Table columnTable = this.columnsViewer.getTable();
     	columnTable.setHeaderVisible(true);
     	columnTable.setLinesVisible(true);
     	columnTable.setLayout(new TableLayout());
     	
-        this.columnsViewer = new TableViewer(columnTable);
         GridDataFactory.fillDefaults().grab(true, true).applyTo(columnsViewer.getControl());
         //GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 200).applyTo(columnsViewer.getControl());
 

--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/TeiidXmlFileInfo.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/wizards/xmlfile/TeiidXmlFileInfo.java
@@ -13,15 +13,16 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.teiid.core.designer.util.CoreArgCheck;
 import org.teiid.core.designer.util.I18nUtil;
-import org.teiid.core.designer.util.StringUtilities;
-import org.teiid.datatools.connectivity.model.Parameter;
+import org.teiid.core.designer.util.StringConstants;
 import org.teiid.designer.core.ModelerCore;
 import org.teiid.designer.query.IProcedureService;
 import org.teiid.designer.query.IQueryService;
@@ -70,12 +71,12 @@ public class TeiidXmlFileInfo extends TeiidFileInfo implements UiConstants, ITei
      * Usually of the form '$d/MedlineCitationSet/MedlineCitation'. In this case, the expression defines the initial path
      * inside the XML structure that the COLUMN PATH's are relative to
      */
-	private String rootPath = StringUtilities.EMPTY_STRING;
+	private String rootPath = StringConstants.EMPTY_STRING;
 	
 	/**
 	 * Common Root path
 	 */
-	private String commonRootPath = StringUtilities.EMPTY_STRING;
+	private String commonRootPath = StringConstants.EMPTY_STRING;
 	
 	/**
 	 * Indicator for the import processor to attempt to create a View Table given the info in this object.
@@ -156,13 +157,13 @@ public class TeiidXmlFileInfo extends TeiidFileInfo implements UiConstants, ITei
 		if( info.getViewTableName() != null ) {
 			setViewTableName(info.getViewTableName());
 		} else {
-			setViewTableName(StringUtilities.EMPTY_STRING);
+			setViewTableName(StringConstants.EMPTY_STRING);
 		}
 		
 		if( info.getViewProcedureName() != null ) {
 			setViewProcedureName(info.getViewProcedureName());
 		} else {
-			setViewProcedureName(StringUtilities.EMPTY_STRING);
+			setViewProcedureName(StringConstants.EMPTY_STRING);
 		}
 		
 		validate();
@@ -672,7 +673,7 @@ public class TeiidXmlFileInfo extends TeiidFileInfo implements UiConstants, ITei
 	 */
 	@Override
 	public Map<String, Object> getParameterMap() {
-		return this.parameterMap;
+		return this.parameterMap==null ? Collections.EMPTY_MAP : this.parameterMap;
 	}
 
 	/**

--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/editor/panels/ModelDetailsPanel.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/editor/panels/ModelDetailsPanel.java
@@ -241,7 +241,7 @@ public class ModelDetailsPanel {
 			// Table containing Source  binding NAME, TRANSLATOR NAME, JNDI NAME
 			BINDING_TABLE : {
 		        // Create Table Viewer
-		        int tableStyle = SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER;
+		        int tableStyle = SWT.SINGLE | SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER;
 		        bindingsViewer = new TableViewer(lowerPanel, tableStyle);
 
 		        Table table = bindingsViewer.getTable();


### PR DESCRIPTION
Resolves several issues that were idenfied on Windows.  Most of the issues were due to TableViewer not having SWT.FULL_SELECTION specified.  Apparently linux is more forgiving than windows on this, because linux operation was ok.
- TEIIDDES-2291 - VDB Editor DataRoles definition - checkbox selection issue
- TEIIDDES-2293 - VDB Editor source binding editing issues
- TEIIDDES-2294 - Relational View Procedure editing issues
- TEIIDDES-2295 - Relational View Table editing issues
