### PR TITLE
TEIIDDES-2299: Improve the performance of ldap wizard checkbox selection

### DIFF
--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/LdapImportWizardManager.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/LdapImportWizardManager.java
@@ -263,15 +263,14 @@ public class LdapImportWizardManager implements IChangeNotifier {
      * Add an attribute to the collection of selected attributes
      *
      * @param attribute
-     * @throws Exception
      */
-    public void addAttribute(ILdapAttributeNode attribute) throws Exception {
+    public void addAttribute(ILdapAttributeNode attribute) {
         ILdapEntryNode associatedEntry = attribute.getAssociatedEntry();
 
         // Prefer the version already in the import manager
         associatedEntry = ldapEntryNodes.get(associatedEntry.hashCode());
         if (associatedEntry == null)
-            throw new Exception(getString("noEntryForAttribute")); //$NON-NLS-1$
+            return;
 
         associatedEntry.addAttribute(attribute);
         notifyChanged();
@@ -281,15 +280,14 @@ public class LdapImportWizardManager implements IChangeNotifier {
      * Removes an attribute from the set of selected attributes
      *
      * @param attribute
-     * @throws Exception
      */
-    public void removeAttribute(ILdapAttributeNode attribute) throws Exception {
+    public void removeAttribute(ILdapAttributeNode attribute) {
         ILdapEntryNode associatedEntry = attribute.getAssociatedEntry();
 
         // Prefer the version already in the import manager
         associatedEntry = ldapEntryNodes.get(associatedEntry.hashCode());
         if (associatedEntry == null)
-            throw new Exception(getString("noEntryForAttribute")); //$NON-NLS-1$
+            return;
 
         if (associatedEntry.removeAttribute(attribute))
             notifyChanged();
@@ -449,11 +447,6 @@ public class LdapImportWizardManager implements IChangeNotifier {
      * @param synchronising
      */
     public void setSynchronising(boolean synchronising) {
-        boolean oldSync = this.synchronising;
         this.synchronising = synchronising;
-
-        // Only notify if sync value has actually changed
-        if (!synchronising && oldSync)
-            notifyChanged();
     }
 }

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/columns/LdapEntryLabelProvider.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/columns/LdapEntryLabelProvider.java
@@ -7,7 +7,6 @@
 */
 package org.teiid.designer.modelgenerator.ldap.ui.wizards.pages.columns;
 
-import org.eclipse.swt.graphics.Image;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.AbstractLdapLabelProvider;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.ILdapAttributeNode;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.ILdapEntryNode;
@@ -33,19 +32,6 @@ public class LdapEntryLabelProvider extends AbstractLdapLabelProvider {
 
         if (element instanceof ILdapAttributeNode) {
             return ((ILdapAttributeNode)element).getId();
-        }
-
-        return null;
-    }
-
-    @Override
-    public Image getImage(Object element) {
-        if (element instanceof ILdapAttributeNode) {
-            ILdapAttributeNode attribute = (ILdapAttributeNode) element;
-            if (getImportManager().attributeSelected(attribute))
-                return CHECKED_IMAGE;
-            else
-                return UNCHECKED_IMAGE;
         }
 
         return null;

--- a/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/table/LdapConnectionLabelProvider.java
+++ b/plugins/org.teiid.designer.modelgenerator.ldap.ui/src/org/teiid/designer/modelgenerator/ldap/ui/wizards/pages/table/LdapConnectionLabelProvider.java
@@ -7,7 +7,6 @@
 */
 package org.teiid.designer.modelgenerator.ldap.ui.wizards.pages.table;
 
-import org.eclipse.swt.graphics.Image;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.AbstractLdapLabelProvider;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.ILdapEntryNode;
 import org.teiid.designer.modelgenerator.ldap.ui.wizards.LdapImportWizardManager;
@@ -38,20 +37,5 @@ public class LdapConnectionLabelProvider extends AbstractLdapLabelProvider {
         }
 
         return null;
-    }
-
-    @Override
-    public Image getImage(Object element) {
-        if (! (element instanceof ILdapEntryNode))
-            return null;
-
-        ILdapEntryNode node = (ILdapEntryNode) element;
-        if (node.isRoot())
-            return null;
-
-        if (getImportManager().entrySelected(node))
-            return CHECKED_IMAGE;
-        else
-            return UNCHECKED_IMAGE;
     }
 }


### PR DESCRIPTION
* LdapImportWizardManager
 * Stop setSynchronising from notifying that it has changed as this is
   calling update in the middle of user-selection operations. Not least
   it is simply a flag that is observed via isSynchronising()

* Ldap[Columns|Tables]Page
 * Refactor the tree viewers of these pages to be CheckboxTreeViewers as
   this avoids the expensive method of WidgetUtil.findTreeItem().
 * With the change to setSynchronising the performance of the trees is much
   improved