### PR TITLE
TEIIDDES-2418 Fixes DataType reconciler table update problem

### DIFF
--- a/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/reconciler/datatype/DatatypeReconcilerPanel.java
+++ b/plugins/org.teiid.designer.transformation.ui/src/org/teiid/designer/transformation/ui/reconciler/datatype/DatatypeReconcilerPanel.java
@@ -444,7 +444,7 @@ public class DatatypeReconcilerPanel extends SashForm implements ISelectionChang
         bindingListInput.datatypeChanged();
 
         // Refresh
-        bindingTableViewer.refresh(true);
+        bindingTableViewer.refresh();
         updateRowColors();
         updateMessageArea();
 
@@ -467,7 +467,7 @@ public class DatatypeReconcilerPanel extends SashForm implements ISelectionChang
         bindingListInput.datatypeChanged();
 
         // Refresh
-        bindingTableViewer.refresh(true);
+        bindingTableViewer.refresh();
         updateRowColors();
         updateMessageArea();
 
@@ -489,7 +489,7 @@ public class DatatypeReconcilerPanel extends SashForm implements ISelectionChang
         bindingListInput.datatypeChanged();
         
         // Refresh
-        bindingTableViewer.refresh(true);
+        bindingTableViewer.refresh(binding);
         updateRowColors();
         updateMessageArea();
 
@@ -512,7 +512,7 @@ public class DatatypeReconcilerPanel extends SashForm implements ISelectionChang
         
         bindingListInput.datatypeChanged();
         // Refresh table and message area
-        bindingTableViewer.refresh(true);
+        bindingTableViewer.refresh(binding);
         updateRowColors();
         updateMessageArea();
 


### PR DESCRIPTION
- corrects the viewer.refresh method calls.  It was supplying a 'true' arg, but that's not what is expected.  For full table refresh, now just using the no arg method to refresh the whole table.