### PR TITLE
teiiddes-2542

### DIFF
--- a/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/ParameterPanel.java
+++ b/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/ParameterPanel.java
@@ -282,7 +282,7 @@ public class ParameterPanel implements DatatoolsUiConstants {
             String defaultValue = dialog.getDefaultValue();
             Parameter parameter = new Parameter(name, defaultValue, Parameter.Type.fromValue(type));
 
-            this.parameterMap.put(name, parameter);
+            this.parameterMap.put(Parameter.PREFIX+name, parameter);
             
             // update UI from model
             this.propertiesViewer.refresh();
@@ -326,14 +326,14 @@ public class ParameterPanel implements DatatoolsUiConstants {
         assert (selectedProperty != null);
 
         // update model
-        parameterMap.remove(selectedProperty.getName());
+        parameterMap.remove(Parameter.PREFIX+selectedProperty.getName());
 
         // update UI
         this.propertiesViewer.refresh();
         
         if (this.wsProfileDetailsWizardPage!=null){
         	wsProfileDetailsWizardPage.setParameterMap(this.parameterMap);
-        	wsProfileDetailsWizardPage.getProfileProperties().remove(selectedProperty.getName());
+        	wsProfileDetailsWizardPage.getProfileProperties().remove(Parameter.PREFIX+selectedProperty.getName());
         	wsProfileDetailsWizardPage.urlPreviewText.setText(wsProfileDetailsWizardPage.updateUrlPreview().toString());
         }else{
         	propertyPage.setParameterMap(this.parameterMap);

--- a/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/PropertyPage.java
+++ b/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/PropertyPage.java
@@ -350,7 +350,7 @@ public class PropertyPage extends ProfileDetailsPropertyPage implements
 	    	  }else{
 	    		  parameterString.append("&");   //$NON-NLS-1$  
 	    	  }
-	    	  parameterString.append(key).append("=").append(value.getDefaultValue()); //$NON-NLS-1$
+	    	  parameterString.append(value.getName()).append("=").append(value.getDefaultValue()); //$NON-NLS-1$
 	      }
 	    }
 
@@ -501,7 +501,6 @@ public class PropertyPage extends ProfileDetailsPropertyPage implements
     private void loadParameters(Properties props) {
     	for( Object key : props.keySet() )  {
     		String keyStr = (String)key;
-    		
     		if( keyStr.startsWith(Parameter.PREFIX)) {
     			Parameter newParam = new Parameter(keyStr, props.getProperty((String)key));
     			parameterMap.put(newParam.getName(), newParam);

--- a/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/WSProfileDetailsWizardPage.java
+++ b/plugins/org.teiid.designer.datatools.ui/src/org/teiid/designer/datatools/profiles/ws/WSProfileDetailsWizardPage.java
@@ -315,7 +315,7 @@ public class WSProfileDetailsWizardPage extends ScrolledConnectionProfileDetails
 				} else {
 					parameterString.append("&"); //$NON-NLS-1$  
 				}
-				parameterString.append(encodeString(key)).append("=").append(encodeString(value.getDefaultValue())); //$NON-NLS-1$
+				parameterString.append(encodeString(value.getName())).append("=").append(encodeString(value.getDefaultValue())); //$NON-NLS-1$
 			}
 		}
 


### PR DESCRIPTION
The key value was not always unique since we were not consistently using "rest_param:" when adding entries to the map which created apparent duplicate entries. Changed logic to consistently prefix the map key value with "rest_param:".