### PR TITLE
TEIIDDES-2549: Support server versions micro-greater than supported d…

### DIFF
--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/ServerVersionGuard.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/ServerVersionGuard.java
@@ -45,8 +45,14 @@ public class ServerVersionGuard implements IExecutionConfigurationListener, Stri
             return;
 
         ITeiidServer instance = event.getUpdatedServer();
+        if (instance == null)
+            return;
+
         ITeiidServerVersion version = instance.getServerVersion();
-        if (! version.isGreaterThan(TeiidServerVersion.Version.TEIID_DEFAULT.get()))
+
+        ITeiidServerVersion defaultVersion = TeiidServerVersion.Version.TEIID_DEFAULT.get();
+        ITeiidServerVersion mmVersion = new TeiidServerVersion(defaultVersion.getMajor(), defaultVersion.getMinor(), ITeiidServerVersion.WILDCARD);
+        if (version.isLessThanOrEqualTo(mmVersion))
             return;
 
         IWorkbench workbench = DqpUiPlugin.getDefault().getWorkbench();

--- a/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/SetDefaultServerAction.java
+++ b/plugins/org.teiid.designer.dqp.ui/src/org/teiid/designer/runtime/ui/server/SetDefaultServerAction.java
@@ -140,8 +140,8 @@ public class SetDefaultServerAction extends BaseSelectionListenerAction implemen
         }
 
         /*
-         * If a server version change is occurring then tell the user and ask them if its
-         * alright to continue since this will close any open editors.
+         * If a server version change is occurring and the new server has a version that is not full
+         * support then ask the user if it is ok to continue.
          */
         continueChangingServer = false;
         SupportLevel level = ModelerCore.getTeiidSupportLevel(selectedServer.getServerVersion());

--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/IExecutionAdminFactory.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/runtime/spi/IExecutionAdminFactory.java
@@ -10,7 +10,6 @@ package org.teiid.designer.runtime.spi;
 import java.sql.Driver;
 import org.teiid.designer.query.IQueryService;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
-import org.teiid.designer.runtime.version.spi.TeiidServerVersion;
 import org.teiid.designer.type.IDataTypeManagerService;
 
 /**
@@ -20,7 +19,7 @@ public interface IExecutionAdminFactory {
 
     /**
      * The support level to return from the
-     * {@link IExecutionAdminFactory#supports(TeiidServerVersion)}
+     * {@link IExecutionAdminFactory#supports(ITeiidServerVersion)}
      * support method
      */
     enum SupportLevel {

--- a/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/admin/ExecutionAdminFactory.java
+++ b/plugins/teiid/org.teiid.runtime.client/src/org/teiid/runtime/client/admin/ExecutionAdminFactory.java
@@ -39,7 +39,10 @@ public class ExecutionAdminFactory implements IExecutionAdminFactory {
         if (version.isLessThan(TeiidServerVersion.Version.TEIID_7_7.get()))
             return SupportLevel.NO_SUPPORT;
 
-        if (version.isLessThanOrEqualTo(TeiidServerVersion.Version.TEIID_DEFAULT.get()))
+        // Only compare major-minor versions
+        ITeiidServerVersion defaultVersion = TeiidServerVersion.Version.TEIID_DEFAULT.get();
+        ITeiidServerVersion mmVersion = new TeiidServerVersion(defaultVersion.getMajor(), defaultVersion.getMinor(), ITeiidServerVersion.WILDCARD);
+        if (version.isLessThanOrEqualTo(mmVersion))
             return SupportLevel.FULL_SUPPORT;
 
         return SupportLevel.WORKS;


### PR DESCRIPTION
…efault

* Where the default server version is 8.7.0, avoid throwing up the
  "unsupported server" messages for versions such as 8.7.1, 8.7.2 etc..

* ServerVersionGuard
* ExecutionAdminFactory
 * Test against the wildcard rendition of the default server version