### PR TITLE
TEIIDDES-2562: cache hint being lost from Create Procedure Command

### DIFF
--- a/plugins/teiid/org.teiid.runtime.client/api/org/teiid/translator/CacheDirective.java
+++ b/plugins/teiid/org.teiid.runtime.client/api/org/teiid/translator/CacheDirective.java
@@ -23,9 +23,9 @@
 package org.teiid.translator;
 
 import java.io.Serializable;
-
 import org.teiid.core.util.EquivalenceUtil;
 import org.teiid.core.util.HashCodeUtil;
+import org.teiid.query.parser.TeiidParser;
 
 public class CacheDirective implements Serializable {
 	
@@ -52,7 +52,9 @@ public class CacheDirective implements Serializable {
 	}
 
 	private static final long serialVersionUID = -4119606289701982511L;
-	
+
+	private final TeiidParser teiidParser;
+
 	private Boolean prefersMemory;
 	private Boolean updatable;
 	private Boolean readAll;
@@ -60,13 +62,22 @@ public class CacheDirective implements Serializable {
 	private Scope scope;
 	private Invalidation invalidation = Invalidation.NONE;
 	
-	public CacheDirective() {
+	public CacheDirective(TeiidParser teiidParser) {
+	    this.teiidParser = teiidParser;
 	}
 	
-	public CacheDirective(Boolean prefersMemory, Long ttl) {
+	public CacheDirective(TeiidParser teiidParser, Boolean prefersMemory, Long ttl) {
+	    this(teiidParser);
 		this.prefersMemory = prefersMemory;
 		this.ttl = ttl;
 	}
+
+	/**
+     * @return the teiidParser
+     */
+    public TeiidParser getTeiidParser() {
+        return this.teiidParser;
+    }
 
 	public Boolean getPrefersMemory() {
 		return prefersMemory;

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/parser/AbstractTeiidParser.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/parser/AbstractTeiidParser.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.teiid.core.types.DataTypeManagerService;
 import org.teiid.core.util.StringUtil;
 import org.teiid.designer.annotation.Removed;
@@ -393,7 +392,7 @@ public abstract class AbstractTeiidParser implements TeiidParser {
 	public CacheHint getQueryCacheOption(String query) {
     	Matcher match = CACHE_HINT.matcher(query);
     	if (match.matches()) {
-    		CacheHint hint = new CacheHint();
+    	    CacheHint hint = new CacheHint(this);
     		if (match.group(2) !=null) {
     			hint.setPrefersMemory(true);
     		}

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/parser/QueryParser.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/parser/QueryParser.java
@@ -25,12 +25,10 @@ package org.teiid.query.parser;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.HashSet;
-
 import org.teiid.designer.annotation.Removed;
 import org.teiid.designer.annotation.Since;
 import org.teiid.designer.query.IQueryParser;
 import org.teiid.designer.runtime.version.spi.ITeiidServerVersion;
-import org.teiid.designer.runtime.version.spi.TeiidServerVersion;
 import org.teiid.designer.runtime.version.spi.TeiidServerVersion.Version;
 import org.teiid.metadata.FunctionMethod;
 import org.teiid.metadata.MetadataFactory;
@@ -203,22 +201,24 @@ public class QueryParser implements IQueryParser {
         
     	Command result = null;
         try{
+            TeiidParser teiidParser = getTeiidParser(sql);
             if (designerCommands) {
-                result = getTeiidParser(sql).designerCommand(parseInfo);
+                result = teiidParser.designerCommand(parseInfo);
             } else {
-                result = getTeiidParser(sql).command(parseInfo);
+                result = teiidParser.command(parseInfo);
             }
             String noCommentSql = sql;
-            LeadingComment leadingComment = getTeiidParser(sql).getLeadingComment(sql);
-            TrailingComment trailingComment = getTeiidParser(sql).getTrailingComment(noCommentSql);
-            
+            LeadingComment leadingComment = teiidParser.getLeadingComment(sql);
+            TrailingComment trailingComment = teiidParser.getTrailingComment(noCommentSql);
+
             if( leadingComment != null ) {
-            	noCommentSql = getTeiidParser(sql).removeComments(sql, leadingComment, trailingComment);
+            	noCommentSql = teiidParser.removeComments(sql, leadingComment, trailingComment);
             }
+
             result.setLeadingComment(leadingComment);
             result.setTrailingComment(trailingComment);
-            
-            result.setCacheHint(getTeiidParser(sql).getQueryCacheOption(noCommentSql));
+
+            result.setCacheHint(teiidParser.getQueryCacheOption(noCommentSql));
 
         } catch(Exception e) {
            throw convertParserException(e);

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/lang/CacheHint.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/lang/CacheHint.java
@@ -23,6 +23,8 @@
 package org.teiid.query.sql.lang;
 
 import org.teiid.metadata.FunctionMethod.Determinism;
+import org.teiid.query.parser.TeiidParser;
+import org.teiid.query.sql.visitor.SQLStringVisitor;
 import org.teiid.translator.CacheDirective;
 
 public class CacheHint extends CacheDirective {
@@ -35,11 +37,12 @@ public class CacheHint extends CacheDirective {
 	public static final String CACHE = "cache"; //$NON-NLS-1$
 	public static final String SCOPE = "scope:"; //$NON-NLS-1$
 	
-	public CacheHint() {
+	public CacheHint(TeiidParser parser) {
+	    super(parser);
 	}
 	
-	public CacheHint(Boolean prefersMemory, Long ttl) {
-		super(prefersMemory, ttl);
+	public CacheHint(TeiidParser teiidParser, Boolean prefersMemory, Long ttl) {
+		super(teiidParser, prefersMemory, ttl);
 	}
 	
 	public boolean isPrefersMemory() {
@@ -51,10 +54,9 @@ public class CacheHint extends CacheDirective {
 
 	@Override
 	public String toString() {
-		// TODO: fix this?
-//		SQLStringVisitor ssv = new SQLStringVisitor();
-//		ssv.addCacheHint(this);
-		return null;
+	    SQLStringVisitor ssv = new SQLStringVisitor(getTeiidParser().getVersion());
+	    ssv.addCacheHint(this);
+		return ssv.getSQLString();
 	}
 	
 	public Determinism getDeterminism() {
@@ -86,7 +88,7 @@ public class CacheHint extends CacheDirective {
 	}
 	
 	public CacheHint clone() {
-		CacheHint copy = new CacheHint();
+		CacheHint copy = new CacheHint(getTeiidParser());
 		copy.setInvalidation(this.getInvalidation());
 		copy.setPrefersMemory(this.getPrefersMemory());
 		copy.setReadAll(this.getReadAll());

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import org.teiid.core.types.ArrayImpl;
 import org.teiid.core.types.DataTypeManagerService;
 import org.teiid.core.util.StringUtil;
@@ -2327,6 +2326,7 @@ public class SQLStringVisitor extends LanguageVisitor
     @Override
     public void visit(CreateProcedureCommand obj) {
     	addLeadingComment(obj.getLeadingComment());
+    	addCacheHint(obj.getCacheHint());
         if (isLessThanTeiidVersion(Version.TEIID_8_4)) {
             append(CREATE);
             append(SPACE);


### PR DESCRIPTION
* SQLStringVisitor
 * cache hint addition being missed while visiting CreateProcedureCommand

* CacheDirective
* CacheHint
 * adds parser as field to allow toString() method to work correctly
 * implements toString method

* QueryParser
 * Reduces number of TeiidParser instances being created