### PR TITLE
Fix For TEIIDDES-2620 and TEIIDDES-2611

### DIFF
--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/i18n.properties
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/i18n.properties
@@ -993,3 +993,5 @@ invalidPropertyEditorValue = "{0}" is not a valid {1} value
 invalidNullPropertyValue = The property "{0}" must have a value.
 missingPropertyDefinition = No property definition found for property "{0}."
 unknownPropertyType = Property "{0}" has an unknown type of "{1}."
+
+CircularDependenciesRule.errorMsg = Circular dependencies have been detected in model "{0}" involving model "{1}".

--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/validation/ValidationRuleManager.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/validation/ValidationRuleManager.java
@@ -20,6 +20,7 @@ import org.teiid.designer.core.metamodel.aspect.ValidationAspect;
 import org.teiid.designer.core.metamodel.aspect.core.aspects.validation.rules.DeletedXmlRelationalExtensionRule;
 import org.teiid.designer.core.metamodel.aspect.core.aspects.validation.rules.DeletedXmlRelationalImportRule;
 import org.teiid.designer.core.resource.EmfResource;
+import org.teiid.designer.core.validation.rules.CircularDependenciesRule;
 import org.teiid.designer.core.validation.rules.EObjectUuidRule;
 import org.teiid.designer.core.validation.rules.EmfResourceValidationRule;
 import org.teiid.designer.core.validation.rules.ModelFileExtensionRule;
@@ -43,6 +44,7 @@ public class ValidationRuleManager {
     private static final ValidationRule RESOURCE_IN_SCOPE_RULE = new ResourceInScopeValidationRule();
     private static final ValidationRule DELETED_XML_RELATIONAL_IMPORT_RULE = new DeletedXmlRelationalImportRule();
     private static final ValidationRule DELETED_XML_RELATIONAL_EXTENSION_RULE = new DeletedXmlRelationalExtensionRule();
+    private static final ValidationRule CIRCULAR_DEPENDENCIES_RULE = new CircularDependenciesRule();
     private LRUCache cache;
 
     // ==================================================================================
@@ -167,6 +169,7 @@ public class ValidationRuleManager {
             ruleSet.addRule(EMF_RESOURCE_RULE);
             ruleSet.addRule(DELETED_XML_RELATIONAL_IMPORT_RULE);
             ruleSet.addRule(DELETED_XML_RELATIONAL_EXTENSION_RULE);
+            ruleSet.addRule(CIRCULAR_DEPENDENCIES_RULE);
         } else if (eResource instanceof XSDResourceImpl) {
             //ruleSet.addRule(FILE_EXTENSION_RULE);
         }

--- a/plugins/org.teiid.designer.core/src/org/teiid/designer/core/validation/rules/CircularDependenciesRule.java
+++ b/plugins/org.teiid.designer.core/src/org/teiid/designer/core/validation/rules/CircularDependenciesRule.java
@@ -1,0 +1,60 @@
+package org.teiid.designer.core.validation.rules;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.teiid.core.designer.util.CoreArgCheck;
+import org.teiid.designer.core.ModelerCore;
+import org.teiid.designer.core.validation.ResourceValidationRule;
+import org.teiid.designer.core.validation.ValidationContext;
+import org.teiid.designer.core.validation.ValidationProblem;
+import org.teiid.designer.core.validation.ValidationProblemImpl;
+import org.teiid.designer.core.validation.ValidationResult;
+import org.teiid.designer.core.validation.ValidationResultImpl;
+import org.teiid.designer.core.workspace.ModelResource;
+import org.teiid.designer.core.workspace.ModelUtil;
+import org.teiid.designer.core.workspace.WorkspaceResourceFinderUtil;
+
+public final class CircularDependenciesRule implements ResourceValidationRule {
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.teiid.designer.core.validation.ResourceValidationRule#validate(org.eclipse.emf.ecore.resource.Resource, org.teiid.designer.core.validation.ValidationContext)
+     */
+    @Override
+    public void validate(final Resource resource,
+                         final ValidationContext context) {
+        CoreArgCheck.isNotNull(resource);
+        CoreArgCheck.isNotNull(context);
+
+        try {
+            final ModelResource modelResource = ModelUtil.getModel(resource);
+
+            if (modelResource != null) {
+                final IResource model = modelResource.getResource();
+
+                if (model != null) {
+                    final IFile circularDependency = WorkspaceResourceFinderUtil.getFirstResourceHavingCircularDependency(model);
+
+                    if (circularDependency != null) {
+                        final ValidationResult result = new ValidationResultImpl(resource, resource);
+                        final String msg = ModelerCore.Util.getString("CircularDependenciesRule.errorMsg",
+                                                                      model.getName(),
+                                                                      circularDependency.getName());
+                        final ValidationProblem problem = new ValidationProblemImpl(IStatus.OK, IStatus.ERROR, msg);
+                        result.addProblem(problem);
+                        context.addResult(result);
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            final ValidationResult result = new ValidationResultImpl(resource, resource);
+            final ValidationProblem problem = new ValidationProblemImpl(IStatus.OK, IStatus.ERROR, e.getLocalizedMessage());
+            result.addProblem(problem);
+            context.addResult(result);
+        }
+    }
+
+}

--- a/plugins/org.teiid.designer.mapping.ui/src/org/teiid/designer/mapping/ui/editor/MappingDiagramController.java
+++ b/plugins/org.teiid.designer.mapping.ui/src/org/teiid/designer/mapping/ui/editor/MappingDiagramController.java
@@ -33,8 +33,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ControlEvent;
-import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Composite;
@@ -78,7 +76,7 @@ import org.teiid.designer.ui.viewsupport.ModelUtilities;
  * @since 8.0
  */
 public class MappingDiagramController
-    implements DiagramController, ISelectionChangedListener, ControlListener, IRevealHideListener, UiConstants {
+    implements DiagramController, ISelectionChangedListener, IRevealHideListener, UiConstants {
 
     DocumentTreeController documentController;
     DiagramEditor diagramEditor;
@@ -967,26 +965,6 @@ public class MappingDiagramController
 
         // jh Defect 21263 - call resetExtents on tree
         documentController.resetExtentsFromDocument();
-    }
-
-    /**
-     * @see org.eclipse.swt.events.ControlListener#controlMoved(org.eclipse.swt.events.ControlEvent)
-     */
-    @Override
-	public void controlMoved( ControlEvent e ) {
-        // Don't care about anything here.
-
-    }
-
-    /**
-     * @see org.eclipse.swt.events.ControlListener#controlResized(org.eclipse.swt.events.ControlEvent)
-     */
-    @Override
-	public void controlResized( ControlEvent e ) {
-        // We need to tell the diagram to update from it's current scroll position
-        if (diagramEditor.getControl() != null && !diagramEditor.getControl().isDisposed()) {
-            documentController.resetExtentsFromDocument();
-        }
     }
 
     /**

--- a/plugins/org.teiid.designer.ui/launch/Designer MacOSX.launch
+++ b/plugins/org.teiid.designer.ui/launch/Designer MacOSX.launch
@@ -18,6 +18,8 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -clean -consoleLog -debug"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=512M"/>

--- a/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
+++ b/plugins/org.teiid.designer.ui/src/org/teiid/designer/ui/explorer/ModelExplorerResourceNavigator.java
@@ -1082,6 +1082,7 @@ public class ModelExplorerResourceNavigator extends ResourceNavigator
         // updateStatusLine(sel);
         updateActionBars(sel);
         linkToEditor(sel);
+        super.handleSelectionChanged(event);
     }
 
     /**

--- a/tests/org.teiid.core.designer.test.framework/src/org/teiid/core/designer/EclipseMock.java
+++ b/tests/org.teiid.core.designer.test.framework/src/org/teiid/core/designer/EclipseMock.java
@@ -9,6 +9,8 @@ package org.teiid.core.designer;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -27,6 +29,7 @@ public final class EclipseMock {
     private final IWorkspace workspace;
     private final IWorkspaceRoot workspaceRoot;
     private final IPath workspaceRootLocation;
+    private final List<IProject> projects = new ArrayList<IProject>();
 
     public EclipseMock() {
         //
@@ -51,6 +54,11 @@ public final class EclipseMock {
         //
         ModelWorkspaceManager.getModelWorkspaceManager();
     }
+
+    public void addProject(final IProject project) {
+        this.projects.add(project);
+        when(workspaceRoot.getProjects()).thenReturn(this.projects.toArray(new IProject[this.projects.size()]));
+    }
     
     public void dispose() throws Exception {
         ModelWorkspaceManager.shutdown();
@@ -58,8 +66,7 @@ public final class EclipseMock {
         Mockito.reset(workspace);
         Mockito.reset(workspaceRoot);
         Mockito.reset(workspaceRootLocation);
-
-        ((RegistrySPI) ModelerCore.getRegistry()).unregister(ModelerCore.WORKSPACE_KEY);
+        this.projects.clear();
     }
 
     /**

--- a/tests/org.teiid.designer.core.test/src/org/teiid/designer/core/test/AllTests.java
+++ b/tests/org.teiid.designer.core.test/src/org/teiid/designer/core/test/AllTests.java
@@ -56,6 +56,7 @@ import org.teiid.designer.core.workspace.TestModelWorkspaceItemCache;
 import org.teiid.designer.core.workspace.TestModelWorkspaceItemInfo;
 import org.teiid.designer.core.workspace.TestModelWorkspaceSelections;
 import org.teiid.designer.core.workspace.TestOpenableModelWorkspaceItemInfo;
+import org.teiid.designer.core.workspace.WorkspaceResourceFinderUtilTest;
 
 
 @RunWith( Suite.class )
@@ -74,7 +75,7 @@ import org.teiid.designer.core.workspace.TestOpenableModelWorkspaceItemInfo;
     TestPrimaryMetamodelStatisticsVisitor.class, TestModelStatisticsVisitor.class, TestModelStatistics.class,
     TestIoUtilities.class, TestColumnRecordComparator.class, StringUtilitiesTest.class, TestDatatypeConstants.class,
     TestMultiplicity.class, TestMappingProducer.class, TestFakeMappableObject.class, TestModelerCore.class,
-    TestTransactionStateConstants.class, TestAbstractMetamodelAspect.class,} )
+    TestTransactionStateConstants.class, TestAbstractMetamodelAspect.class, WorkspaceResourceFinderUtilTest.class} )
 public class AllTests {
     // nothing to do
 }

--- a/tests/org.teiid.designer.core.test/src/org/teiid/designer/core/workspace/WorkspaceResourceFinderUtilTest.java
+++ b/tests/org.teiid.designer.core.test/src/org/teiid/designer/core/workspace/WorkspaceResourceFinderUtilTest.java
@@ -1,0 +1,188 @@
+package org.teiid.designer.core.workspace;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.when;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.teiid.core.designer.EclipseMock;
+import org.teiid.designer.core.ModelWorkspaceMock;
+import org.teiid.designer.core.ModelerCore;
+
+public final class WorkspaceResourceFinderUtilTest {
+
+    private static final String NAME = "MyModel";
+
+    private IResource model;
+    private IProject modelProject;
+    private ModelWorkspaceMock modelWorkspaceMock;
+    private List<IResource> resources = new ArrayList<IResource>();
+
+    @After
+    public void afterEach() throws Exception {
+        this.modelWorkspaceMock.dispose();
+        this.resources.clear();
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Before
+    public void beforeEach() throws Exception {
+        final EclipseMock eclipseMock = new EclipseMock();
+        this.modelWorkspaceMock = new ModelWorkspaceMock(eclipseMock);
+
+        this.modelProject = mock(IProject.class);
+        eclipseMock.addProject(this.modelProject);
+
+        when(this.modelProject.isOpen()).thenReturn(true);
+        when(this.modelProject.getProject()).thenReturn(this.modelProject);
+        when(this.modelProject.hasNature(ModelerCore.NATURE_ID)).thenReturn(true);
+        when(this.modelProject.members()).thenReturn(new IResource[0]);
+
+        // add the workspace resources to the visitor
+        stubVoid(this.modelProject).toAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(final InvocationOnMock invocation) throws Throwable {
+                final Object[] args = invocation.getArguments();
+                final IResourceVisitor visitor = (IResourceVisitor)args[0];
+
+                // add each resource to the visitor
+                for (final IResource resource : getResources()) {
+                    visitor.visit(resource);
+                }
+
+                return null;
+            }
+        }).on().accept(Matchers.<IResourceVisitor>anyVararg());
+
+        { // .project file
+            final File dotFile = File.createTempFile("dotFile", ".project");
+            dotFile.deleteOnExit();
+
+            final IPath path = new Path(dotFile.getAbsolutePath());
+            final IFile dotIfile = mock(IFile.class);
+            when(dotIfile.getName()).thenReturn(".project");
+            when(dotIfile.getType()).thenReturn(IResource.FILE);
+            when(dotIfile.isAccessible()).thenReturn(true);
+            when(dotIfile.getLocation()).thenReturn(path);
+            when(dotIfile.getProject()).thenReturn(this.modelProject);
+
+            when(this.modelProject.getFile(DotProjectUtils.DOT_PROJECT)).thenReturn(dotIfile);
+        }
+
+        this.model = createFile(NAME);
+    }
+
+    List<IResource> getResources() {
+        return this.resources;
+    }
+
+    IWorkspaceRoot getWorkspaceRoot() {
+        return this.modelWorkspaceMock.getEclipseMock().workspaceRoot();
+    }
+
+    @Test
+    public void shouldNotHaveCircularDependenciesWhenNoDependents() {
+        assertThat(WorkspaceResourceFinderUtil.getFirstResourceHavingCircularDependency(this.model), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHaveCircularDependencies() throws Exception {
+        // this.model depends on aaa, aaa depends on bbb, bbb depends on this.model
+        final IFile aaa = createFile("aaa");
+        final IFile bbb = createFile("bbb");
+
+        final String modelHeader = createXmiHeader(aaa.getName());
+        writeFile(this.model.getRawLocation().toFile(), modelHeader);
+
+        final String aaaHeader = createXmiHeader(bbb.getName());
+        writeFile(aaa.getRawLocation().toFile(), aaaHeader);
+
+        final String bbbHeader = createXmiHeader(this.model.getName());
+        writeFile(bbb.getRawLocation().toFile(), bbbHeader);
+
+        assertThat(WorkspaceResourceFinderUtil.getFirstResourceHavingCircularDependency(this.model), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNotHaveCircularDependencies() throws Exception {
+        // this.model depends on aaa
+        final IFile aaa = createFile("aaa");
+
+        final String modelHeader = createXmiHeader(aaa.getName());
+        writeFile(this.model.getRawLocation().toFile(), modelHeader);
+
+        assertThat(WorkspaceResourceFinderUtil.getFirstResourceHavingCircularDependency(this.model), is(nullValue()));
+    }
+
+    private static void writeFile(final File file,
+                                  final String content) throws Exception {
+        Files.write(Paths.get(file.getPath()), content.getBytes());
+    }
+
+    private IFile createFile(final String name) throws Exception {
+        final File file = File.createTempFile(name, ".xmi");
+        file.deleteOnExit();
+
+        final IPath path = new Path(file.getAbsolutePath());
+        final IFile iFile = mock(IFile.class);
+        when(iFile.getName()).thenReturn(file.getName());
+        when(iFile.getLocation()).thenReturn(path);
+        when(iFile.getRawLocation()).thenReturn(path);
+        when(iFile.getFullPath()).thenReturn(path);
+        when(iFile.exists()).thenReturn(true);
+        when(iFile.getType()).thenReturn(IResource.FILE);
+        when(iFile.getProject()).thenReturn(this.modelProject);
+        this.resources.add(iFile);
+
+        when(this.modelProject.members()).thenReturn(this.resources.toArray(new IResource[this.resources.size()]));
+        when(this.modelProject.findMember(path)).thenReturn(iFile);
+        when(this.modelProject.findMember(path.toString())).thenReturn(iFile);
+        return iFile;
+    }
+
+    private String createXmiHeader(final String... modelsToImport) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("<?xml version=\"1.0\" encoding=\"ASCII\"?> <xmi:XMI xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:diagram=\"http://www.metamatrix.com/metamodels/Diagram\" xmlns:mmcore=\"http://www.metamatrix.com/metamodels/Core\" xmlns:mmws=\"http://www.metamatrix.com/metamodels/WebService\" xmlns:transformation=\"http://www.metamatrix.com/metamodels/Transformation\">");
+        builder.append("<mmcore:ModelAnnotation xmi:uuid=\"mmuuid:ae435d62-1cff-4038-ae14-4a5fdf5fd417\" primaryMetamodelUri=\"http://www.metamatrix.com/metamodels/WebService\" modelType=\"VIRTUAL\" ProducerName=\"Teiid Designer\" ProducerVersion=\"9.2.0\">");
+
+        int i = 0;
+
+        if ((modelsToImport != null) && (modelsToImport.length != 0)) {
+            for (final String model : modelsToImport) {
+                final String modelName = model.substring(0, model.indexOf(".xmi"));
+
+                builder.append("<modelImports xmi:uuid=\"mmuuid:96eda359-0832-46e7-9e33-c878a3603dc").append(i).append("\" ");
+                builder.append("name=\"").append(modelName).append("\" modelLocation=\"").append(model).append("\" uuid=\"mmuuid:88b08082-c021-4c3a-a4a3-148f5e58dc3").append(i).append("\" ");
+                builder.append("modelType=\"VIRTUAL\" primaryMetamodelUri=\"http://www.metamatrix.com/metamodels/XmlDocument\"/>");
+                ++i;
+            }
+        }
+
+        builder.append("</mmcore:ModelAnnotation>");
+        builder.append("</xmi:XMI>");
+
+        return builder.toString();
+    }
+
+}


### PR DESCRIPTION
TEIIDDES-2620 Add validation rule to check for circular dependencies in view models
TEIIDDES-2611 Resize transformation editor crash Developer Studio
- added validation rule to detect circular dependencies
- fixed WorkspaceResourceFinderUtil.getResourcesThatUse so that it can handle circular dependencies
- created WorkspaceResourceFinderUtilTest to test the new circular dependency method
- Removed MappingDiagramController control listener that was causing display issues when the splitter was moved in the mapping editor