### PR TITLE
teiiddes-2656

### DIFF
--- a/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/WsdlDefinitionPage.java
+++ b/plugins/org.teiid.designer.modelgenerator.wsdl.ui/src/org/teiid/designer/modelgenerator/wsdl/ui/wizards/soap/WsdlDefinitionPage.java
@@ -741,7 +741,8 @@ public class WsdlDefinitionPage extends WizardPage
 	private boolean teiidRelatedPropertiesAreEqual(
 			Properties firstProps, Properties secondProps) {
         
-		if (firstProps==null || secondProps == null) return true;
+		if ((secondProps!=null &&  firstProps == null) ||
+		   (firstProps!=null &&  secondProps == null)) return false;
 		
         String firstPassword = firstProps.getProperty(ICredentialsCommon.PASSWORD_PROP_ID);
         String secondPassword = secondProps.getProperty(ICredentialsCommon.PASSWORD_PROP_ID);


### PR DESCRIPTION
Modified check for previous and current connection profile to check for one null and one non-null when comparing for updating the page. This will cause the WSDL URI to be set and allow the page to load properly.