### PR TITLE
TEIIDDES-2458 Fix name in source for Sybase

### DIFF
--- a/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/i18n.properties
+++ b/plugins/org.teiid.designer.jdbc.relational/src/org/teiid/designer/jdbc/relational/i18n.properties
@@ -33,6 +33,7 @@ RelationalModelProcessorImpl.Error_while_computing_datatype = Error while comput
 RelationalModelProcessorImpl.ResultSetName=ResultSet
 RelationalModelProcessorImpl.Error_while_obtaining_quote_string = Error while obtaining quote string for {0}
 RelationalModelProcessorImpl.Error_while_obtaining_catalogs = Error while obtaining catalogs string for {0}
+RelationalModelProcessorImpl.Error_while_obtaining_name_in_source = Unable to obtain correct name in source for {0} 
 
 RelationalModelProcessorImpl.importDescription = JDBC Import
 


### PR DESCRIPTION
Attempt to set the correct name in source for tables imported from
Sybase. Sybase does not return a list of schemas, but still requires the
fully qualified name to include the owner.

We workaround this by obtaining the metadata for each imported table and
getting the "schema" from there.

In case of any problem, we fall back on the original behaviour.