### PR TITLE
Small fixes for SQL syntax comments

### DIFF
--- a/plugins/org.teiid.designer.spi/src/org/teiid/designer/query/sql/ISQLStringVisitor.java
+++ b/plugins/org.teiid.designer.spi/src/org/teiid/designer/query/sql/ISQLStringVisitor.java
@@ -30,6 +30,24 @@ public interface ISQLStringVisitor<LO extends ILanguageObject> extends ILanguage
     String returnSQLString(LO languageObject);
 
     /**
+     * Disables comments by adding an id from the given
+     * Object to the comments tag set. If any tags exist
+     * then comments are disabled. Thus, to re-enable
+     * comments the same object should be passed
+     * into {@link #enableComments(Object)}
+     *
+     */
+    void disableComments(Object obj);
+
+    /**
+     * Only removes the exact id of the object
+     * from the comment tag set. Only when
+     * the set is empty will comments be
+     * re-enabled.
+     */
+    void enableComments(Object obj);
+
+    /**
      * @param token
      * @return id tokens properly escaped
      */

--- a/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
+++ b/plugins/teiid/org.teiid.runtime.client/engine/org/teiid/query/sql/visitor/SQLStringVisitor.java
@@ -479,31 +479,13 @@ public class SQLStringVisitor extends LanguageVisitor
         return nextAvailableSpace(sql, cmtIdx);
     }
 
-    /*
-     * Only removes the exact id of this value
-     * from the set. Once the set is empty will
-     * adding comments be re-enabled.
-     */
-    private void enableComments(LanguageObject obj) {
+    @Override
+    public void enableComments(Object obj) {
         ALLOW_COMMENTS.remove(obj.getClass().getSimpleName() + System.identityHashCode(obj));
     }
 
-    /*
-     * Append the string value of a LanguageObject will
-     * launch a new instance of this SQLStringVisitor in
-     * order to produce the string version of the object.
-     *
-     * This will cause the comments to be inserted in the
-     * wrong positions so disable them and confine them
-     * to the SQLStringVisitor.
-     *
-     * Since this method can be called multiple times in
-     * 'child' SQLStringVisitors, need to be sure that we
-     * can identify what value caused the comments to
-     * be turned off hence using a set with the identity
-     * hashcode value of the object.
-     */
-    private void disableComments(LanguageObject obj) {
+    @Override
+    public void disableComments(Object obj) {
         ALLOW_COMMENTS.add(obj.getClass().getSimpleName() + System.identityHashCode(obj));
     }
 

--- a/tests/org.teiid.designer.query.ui.test/src/org/teiid/query/ui/sqleditor/component/TestDisplayNodeWithComments.java
+++ b/tests/org.teiid.designer.query.ui.test/src/org/teiid/query/ui/sqleditor/component/TestDisplayNodeWithComments.java
@@ -32,40 +32,55 @@ public class TestDisplayNodeWithComments implements StringConstants {
     }
 
     @Test
-    public void testSimple1() throws Exception {
-        String sql = "/*+ cache(ttl:300000) */" + NEW_LINE +
-                            "SELECT" + NEW_LINE +
-                            "/* Comment 1 */ " + "*" + NEW_LINE +
-                            "FROM" + NEW_LINE +
-                            "/* Comment 2 */ " + "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                            "/* Comment 3 */";
-        String expectedSql = "/*+ cache(ttl:300000) */" + NEW_LINE +
+    public void testCommentsSimple() throws Exception {
+        String sql = "/* Comment 1 */ SELECT * FROM TABLE_A";
+        String expectedSql = "/* Comment 1 */" + NEW_LINE +
                                             "SELECT" + NEW_LINE +
-                                            TAB + TAB + "/* Comment 1 */" + NEW_LINE +
                                             TAB + TAB + "*" + NEW_LINE +
                                             TAB + "FROM" + NEW_LINE +
-                                            TAB + TAB + "/* Comment 2 */" + NEW_LINE + 
+                                            TAB + TAB + "TABLE_A";
+        helpTest(sql, expectedSql);
+    }
+
+    @Test
+    public void testSimple1() throws Exception {
+        String sql = "/*+ cache(ttl:300000) */" + NEW_LINE +
+                            "/* Comment 1 */ " + NEW_LINE +
+                            "SELECT" + NEW_LINE +
+                            "/* Comment 2 */ " + "*" + NEW_LINE +
+                            "FROM" + NEW_LINE +
+                            "/* Comment 3 */ " + "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
+                            "/* Comment 4 */";
+        String expectedSql =  "/*+ cache(ttl:300000) */" + NEW_LINE +
+                                            "/* Comment 1 */" + NEW_LINE +
+                                            "SELECT" + NEW_LINE +
+                                            TAB + TAB + "/* Comment 2 */" + NEW_LINE +
+                                            TAB + TAB + "*" + NEW_LINE +
+                                            TAB + "FROM" + NEW_LINE +
+                                            TAB + TAB + "/* Comment 3 */" + NEW_LINE + 
                                             TAB + TAB + "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                                            "/* Comment 3 */";
+                                            "/* Comment 4 */";
         helpTest(sql, expectedSql);
     }
 
     @Test
     public void testSimple2() throws Exception {
         String sql = "/*+ cache(ttl:300000) */" + NEW_LINE +
+                            "/* Comment 1 */" + NEW_LINE +
                             "SELECT" + NEW_LINE +
-                            "/* Comment 1 */ " + "*" + NEW_LINE +
-                            "FROM /* Comment 2 */" + NEW_LINE +
+                            "/* Comment 2 */ " + "*" + NEW_LINE +
+                            "FROM /* Comment 3 */" + NEW_LINE +
                             "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                            "/* Comment 3 */";
+                            "/* Comment 4 */";
         String expectedSql = "/*+ cache(ttl:300000) */" + NEW_LINE +
+                                            "/* Comment 1 */" + NEW_LINE +
                                             "SELECT" + NEW_LINE +
-                                            TAB + TAB + "/* Comment 1 */" + NEW_LINE +
+                                            TAB + TAB + "/* Comment 2 */" + NEW_LINE +
                                             TAB + TAB + "*" + NEW_LINE +
                                             TAB + "FROM" + NEW_LINE +
-                                            TAB + TAB + "/* Comment 2 */" + NEW_LINE + 
+                                            TAB + TAB + "/* Comment 3 */" + NEW_LINE + 
                                             TAB + TAB + "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                                            "/* Comment 3 */";
+                                            "/* Comment 4 */";
 
         helpTest(sql, expectedSql);
     }
@@ -73,21 +88,23 @@ public class TestDisplayNodeWithComments implements StringConstants {
     @Test
     public void testLineComments() throws Exception {
         String sql = "/*+ cache(ttl:300000) */" + NEW_LINE +
-                            "SELECT" + NEW_LINE +
                             "-- Comment 1" + NEW_LINE +
+                            "SELECT" + NEW_LINE +
+                            "-- Comment 2" + NEW_LINE +
                             "*" + NEW_LINE +
                             "FROM" + NEW_LINE +
-                            "-- Comment 2" + NEW_LINE +
+                            "-- Comment 3" + NEW_LINE +
                             "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                            "-- Comment 3";
+                            "-- Comment 4";
         String expectedSql = "/*+ cache(ttl:300000) */" + NEW_LINE +
+                                            "-- Comment 1" + NEW_LINE +
                                             "SELECT" + NEW_LINE +
-                                            TAB + TAB + "-- Comment 1" + NEW_LINE +
+                                            TAB + TAB + "-- Comment 2" + NEW_LINE +
                                             TAB + TAB + "*" + NEW_LINE +
                                             TAB + "FROM" + NEW_LINE +
-                                            TAB + TAB + "-- Comment 2" + NEW_LINE + 
+                                            TAB + TAB + "-- Comment 3" + NEW_LINE + 
                                             TAB + TAB + "Products_SQL_Server.products.dbo.ProductData" + NEW_LINE +
-                                            "-- Comment 3" + NEW_LINE;
+                                            "-- Comment 4" + NEW_LINE;
 
         // Only compatible with Teiid 8.10+
         TestUtilities.setDefaultServerVersion(Version.TEIID_8_10.get());

--- a/tests/org.teiid.runtime.client.test/src/org/teiid/query/sql/AbstractTestQueryParser.java
+++ b/tests/org.teiid.runtime.client.test/src/org/teiid/query/sql/AbstractTestQueryParser.java
@@ -6459,4 +6459,11 @@ public abstract class AbstractTestQueryParser extends AbstractTest<Command> {
         String expectedSql = "/* Leading Comment */ SELECT substring(RTRIM(MED.BATDAT), 4, 4) FROM FCC.MEDMAS AS MED /* Trailing Comment */";
         helpTest(sql, expectedSql, null);
     }
+
+    @Test
+    public void testCommentsSimple() {
+        String sql = "/* Comment 1 */ SELECT * FROM TABLE_A";
+        String expectedSql = "/* Comment 1 */ SELECT * FROM TABLE_A";
+        helpTest(sql, expectedSql, null);
+    }
 }


### PR DESCRIPTION
* Let DisplayNode stop the SQLStringVisitor from outputting comments when
  called by its LanguageObject child classes, eg. SelectDisplayNode

* Another swing at controlling tab generation prepended to comments