### PR TITLE
TEIIDDES-2831: Excludes model properties during dynamic vdb conversion

### DIFF
--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/XmiVdb.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/XmiVdb.java
@@ -986,7 +986,22 @@ public final class XmiVdb extends BasicVdb {
                 model.setVisible(entry.isVisible());
 
                 for (Map.Entry<Object, Object> prop : entry.getProperties().entrySet()) {
-                    model.setProperty(prop.getKey().toString(), prop.getValue().toString());
+                    String name = prop.getKey().toString();
+
+                    //
+                    // Not applicable to dynamic vdb models since index files are not used
+                    //
+                    if (EntryElement.INDEX_NAME.equals(name))
+                        continue;
+
+                    //
+                    // Not applicable to dynamic vdb models since models are declarative
+                    // within the vdb rather than in their own files
+                    //
+                    if (EntryElement.CHECKSUM.equals(name))
+                        continue;
+
+                    model.setProperty(name, prop.getValue().toString());
                 }
 
                 DynamicModel.Type type = DynamicModel.Type.fromString(entry.getType());

--- a/tests/org.teiid.designer.vdb.test/src/org/teiid/designer/vdb/dynamic/TestDynamicVdbExport.java
+++ b/tests/org.teiid.designer.vdb.test/src/org/teiid/designer/vdb/dynamic/TestDynamicVdbExport.java
@@ -8,6 +8,7 @@
 package org.teiid.designer.vdb.dynamic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import java.io.File;
@@ -37,6 +38,7 @@ import org.teiid.designer.vdb.VdbModelEntry;
 import org.teiid.designer.vdb.VdbSource;
 import org.teiid.designer.vdb.VdbSourceInfo;
 import org.teiid.designer.vdb.VdbTestUtils;
+import org.teiid.designer.vdb.manifest.EntryElement;
 import org.w3c.dom.Document;
 
 @SuppressWarnings( "javadoc" )
@@ -169,6 +171,16 @@ public class TestDynamicVdbExport implements VdbConstants {
             assertEquals(entry.getDescription(), dynModel.getDescription());
 
             for (Map.Entry<Object, Object> prop : entry.getProperties().entrySet()) {
+                if (EntryElement.INDEX_NAME.equals(prop.getKey())) {
+                    assertFalse(dynModel.getProperties().containsKey(EntryElement.INDEX_NAME));
+                    continue;
+                }
+
+                if (EntryElement.CHECKSUM.equals(prop.getKey())) {
+                    assertFalse(dynModel.getProperties().containsKey(EntryElement.CHECKSUM));
+                    continue;
+                }
+
                 assertEquals(prop.getValue(), dynModel.getProperties().getProperty(prop.getKey().toString()));
             }
 
@@ -319,6 +331,16 @@ public class TestDynamicVdbExport implements VdbConstants {
             assertEquals(entry.getDescription(), dynModel.getDescription());
 
             for (Map.Entry<Object, Object> prop : entry.getProperties().entrySet()) {
+                if (EntryElement.INDEX_NAME.equals(prop.getKey())) {
+                    assertFalse(dynModel.getProperties().containsKey(EntryElement.INDEX_NAME));
+                    continue;
+                }
+
+                if (EntryElement.CHECKSUM.equals(prop.getKey())) {
+                    assertFalse(dynModel.getProperties().containsKey(EntryElement.CHECKSUM));
+                    continue;
+                }
+
                 assertEquals(prop.getValue(), dynModel.getProperties().getProperty(prop.getKey().toString()));
             }
 


### PR DESCRIPTION
* Rather than blindly copying all the model properties, exclude the
  indexName and checksum properties since they are at best irrelevant and
  at worst count-productive to the dynamic vdb.