### PR TITLE
TEIIDDES-3117 - extend warning message

### DIFF
--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/i18n.properties
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/i18n.properties
@@ -49,6 +49,9 @@ VdbResourceChange.syncVdbFailure = Cannot synchronize vdb file from project {0},
 
 XmiVdb.modelNotIncludedMessage = The model {0} is not a relational model and was not included in the generated dynamic VDB
 XmiVdb.fileNotIncludedMessage = The file "{0}" was not included in the generated dynamic VDB
-XmiVdb.udfPropertyAdded = This VDB contains 1 or more UDF jar files. A "lib" property has been added added\n \
+XmiVdb.udfPropertyAdded = This VDB contains 1 or more UDF jar files. A "lib" property has been added\n \
 						  to the VDB xml which references these jars.\n\n \
-                          Note that the actual UDF jars must be deployed for this VDB to be active.\n \
+                          Note that the actual UDF jars must be deployed for this VDB to be active.\n\n \
+                          If you defined UDF as a module in a server, change "lib" property according to\n \
+                          name of that module. For more information, see "Support for User-Defined Features"\n \
+                          in the documentation.\


### PR DESCRIPTION
Extend warning message for users which define UDF as a module with a different name than jar file.