### PR TITLE
TEIIDDES 3142 - add native metadata tag for overriding translator

### DIFF
--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbModelEntry.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/VdbModelEntry.java
@@ -518,7 +518,7 @@ public class VdbModelEntry extends VdbIndexedEntry {
         	for( TranslatorOverride to : overrides) {
         		for( VdbSource source : this.sourceInfo.getSources() ) {
         			String translatorName = source.getTranslatorName();
-	        		if( translatorName != null && !translatorName.toString().equalsIgnoreCase(to.getType()) ) {
+	        		if( translatorName != null && translatorName.toString().equalsIgnoreCase(to.getName()) ) {
 	        			return to;
 	        		}
         		}

--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/XmiVdb.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/XmiVdb.java
@@ -1082,8 +1082,16 @@ public final class XmiVdb extends BasicVdb {
 		                Metadata metadata = new Metadata(ddl, Metadata.Type.DDL);
 		                model.setMetadata(metadata);
                 	}
+                	
+                	String overridedTranslator = null;
+                	if(entry.getTranslatorOverride() != null) {
+                	    overridedTranslator = entry.getTranslatorOverride().getType();
+                	}
+                	
 	                // Check the translator. If infinispan-hotrod then add second metadata tag of type NATIVE
-	                if( singleTranslatorName != null && ModelElement.TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(singleTranslatorName)) {
+	                if( singleTranslatorName != null && 
+	                    (ModelElement.TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(singleTranslatorName) 
+	                    || ModelElement.TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(overridedTranslator))) {
 	                	Metadata metadata = new Metadata(null, Metadata.Type.NATIVE);
 	                	model.setMetadata(metadata);
 	                }


### PR DESCRIPTION
* Added NATIVE metadata tag for overriding translator which source translator is infinispan-hotrod
* Fix getTranslatorOverride() function on VdbModelEntry. Now, the function returns overriding translator only for the model (VdbModelEntry) where is used.

If one model contains overriding translator, getTranslatorOverride() method return this translator for all models from VDB which has set some translator.