### PR TITLE
TEIIDDES 3165 - add native and index metadata tag to .vdb when transl…

### DIFF
--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/ModelElement.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/manifest/ModelElement.java
@@ -174,8 +174,12 @@ public class ModelElement extends EntryElement {
         if( entry.getSchemaText() != null ) {
         	getMetadata().add(new MetadataElement(entry.getSchemaText(), entry.getMetadataType()));
         }
-        
-    	if( TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(singleTranslatorName)) {
+        String overridedTranslator = null;
+        if(entry.getTranslatorOverride() != null) {
+            overridedTranslator = entry.getTranslatorOverride().getType();
+        }
+    	if( TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(singleTranslatorName)
+    	    || TEIID_INFINISPAN_HOTROD_DRIVER.equalsIgnoreCase(overridedTranslator)) {
     		getMetadata().add(new MetadataElement(StringConstants.EMPTY_STRING, INDEX));
     		getMetadata().add(new MetadataElement(StringConstants.EMPTY_STRING, NATIVE));
     	}


### PR DESCRIPTION
The designer adds NATIVE an INDEX metadata tags to the .vdb when a model contains infinispan-hotrod translator. However, when the translator is overriding, the metadata are not added and designer by default override infinispan translator