### PR TITLE
TEIIDDES-3087

### DIFF
--- a/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/editor/panels/PropertiesPanel.java
+++ b/plugins/org.teiid.designer.vdb.ui/src/org/teiid/designer/vdb/ui/editor/panels/PropertiesPanel.java
@@ -63,7 +63,6 @@ public class PropertiesPanel {
 	Button removeLanguageButton;
 	
 	/*
-	 
     	NONE- disallow new connections.
     	BY_VERSION- the default setting. Allow connections only if the version is specified or if this is the earliest BY_VERSION vdb and there are no vdbs marked as ANY.
     	ANY- allow connections with or without a version specified.
@@ -138,10 +137,10 @@ public class PropertiesPanel {
         String type = vdb.getConnectionType();
         if( VdbConstants.ConnectionTypes.ANY.equalsIgnoreCase(type) ) {
         	connectionType.select(2);
-        } else if( VdbConstants.ConnectionTypes.BY_VERSION.equalsIgnoreCase(type) ) {
-        	connectionType.select(1);
-        } else {
-            connectionType.select(0);
+        } else if( VdbConstants.ConnectionTypes.NONE.equalsIgnoreCase(type) ) {
+        	connectionType.select(0);
+        } else { //BY_VERSION which is default
+            connectionType.select(1);
         }
 
         this.connectionType.addModifyListener(new ModifyListener() {

--- a/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/BasicVdb.java
+++ b/plugins/org.teiid.designer.vdb/src/org/teiid/designer/vdb/BasicVdb.java
@@ -91,7 +91,7 @@ public abstract class BasicVdb extends AbstractVdbObject implements Vdb {
 	/*
 	 * NONE, BY_VERSION, ANY
 	 */
-	private String connectionType = VdbConstants.ConnectionTypes.NONE;
+	private String connectionType = VdbConstants.ConnectionTypes.BY_VERSION;
 	// known properties
 	/*
 		<property name="preview" value="false"/>


### PR DESCRIPTION
BY_VERSION connection type was set as default connection type (according to [Teiid documentation](https://teiid.gitbooks.io/documents/content/admin/VDB_Versioning.html)) when VDB doesn't contain any information about this type. Also, BY_VERSION shows in the UI as default.